### PR TITLE
Log an error instead of throwing an exception if the microservice check fails

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
@@ -270,7 +270,8 @@ public class OmeroWebClient {
         }
       }
       else {
-        throw new IOException("Could not check for OMERO microservice (" + response +")");
+        logger.error("Could not check for OMERO microservice ({})", response);
+        hasMicroservice = false;
       }
     }
     finally {


### PR DESCRIPTION
This prevents a dialog that indicates login failed (it didn't) and allows limited functionality for image types that don't require the microservice.