### PR TITLE
Reset CSRF token to null when logging out from a server

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
@@ -554,6 +554,7 @@ public class OmeroWebClient {
 			timer.cancel();
 			timer = null;
 			username.set("");
+			this.token = null;
 		} catch (IOException e) {
 			logger.error("Could not logout.", e.getLocalizedMessage());
 		}


### PR DESCRIPTION
With the current state of the extension, the CRSF token acquired on the first invocation to authenticate is not cleared on logout and thus is getting reused by follow-up authentication calls resulting in CSRF errors.

To reproduce the issue
- install and configure the [0.4.1-gs release of the qupath-extension-omero-web](https://github.com/glencoesoftware/qupath-extension-omero-web/releases/tag/v0.4.1-gs), log into an OMERO server
- log into the OMERO instance using a valid username / passwod
- log out from the OMERO instance
- log in again using the same instance & credentials. QuPath should fail to connect
- the OMERO.web logs should include a `django.security.csrf` WARNING of type `log_response():241 Forbidden (CSRF cookie not set.): /api/v0/login/`

With these changes included in the extension, the workflow above should be sueccessful

/cc @stick @muhanadz  