### PR TITLE
Fix invalid Shape.TheC value

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
@@ -217,11 +217,11 @@ class OmeroShapes {
 	public static abstract class OmeroShape {
 		
 		@SerializedName(value = "TheC")
-		private int c;
+		private Integer c;
 		@SerializedName(value = "TheZ")
-		private int z;
+		private Integer z;
 		@SerializedName(value = "TheT")
-		private int t;
+		private Integer t;
 		
 		@SerializedName(value = "@type")
 		private String type;

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
@@ -217,7 +217,7 @@ class OmeroShapes {
 	public static abstract class OmeroShape {
 		
 		@SerializedName(value = "TheC")
-		private int c = -1;
+		private int c;
 		@SerializedName(value = "TheZ")
 		private int z;
 		@SerializedName(value = "TheT")


### PR DESCRIPTION
Noticed while testing https://github.com/glencoesoftware/ome-omero-roitool/pull/38:

- open any OMERO image in QuPath using this extension
- draw a simple shape
- send annotations back to OMERO
- try to export the annotation with ome-omero-roitool, get an exception because Shape.TheC is -1

ome-omero-roitool will get a companion PR shortly, but this should at least prevent the extension from sending an invalid value. Repeating the same steps as above with this change and a different image should successfully export the ROI to OME-XML.