### PR TITLE
Finish renaming to qupath-extension-omero-web

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: qupath-extension-omero-gs
+          name: qupath-extension-omero-web-gs
           path: build/libs/*.jar
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The main documentation for the extension is at https://qupath.readthedocs.io/en/
 
 ## Installing
 
-To install the OMERO extension, download the latest `qupath-extension-omero-[version].jar` file from [releases](https://github.com/glencoesoftware/qupath-extension-omero/releases) and drag it onto the main QuPath window.
+To install the OMERO extension, download the latest `qupath-extension-omero-web-[version].jar` file from [releases](https://github.com/glencoesoftware/qupath-extension-omero-web/releases) and drag it onto the main QuPath window.
 
 If you haven't installed any extensions before, you'll be prompted to select a QuPath user directory.
 The extension will then be copied to a location inside that directory.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id 'org.bytedeco.gradle-javacpp-platform'
 }
 
-ext.moduleName = 'qupath.extension.omero'
+ext.moduleName = 'qupath.extension.omero-web'
 ext.qupathVersion = gradle.ext.qupathVersion
 ext.qupathJavaVersion = 17
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext.moduleName = 'qupath.extension.omero-web'
 ext.qupathJavaVersion = 17
-archivesBaseName = 'qupath-extension-omero'
+archivesBaseName = 'qupath-extension-omero-web'
 description = "QuPath extension to support image reading using OMERO's web API."
 version = "0.4.3-gs-SNAPSHOT"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'qupath-extension-omero'
+rootProject.name = 'qupath-extension-omero-web'
 
 gradle.ext.qupathVersion = "0.5.0"
 

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroExtension.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroExtension.java
@@ -197,7 +197,7 @@ public class OmeroExtension implements QuPathExtension, GitHubProject {
 
 	@Override
 	public GitHubRepo getRepository() {
-		return GitHubRepo.create(getName(), "qupath", "qupath-extension-omero");
+		return GitHubRepo.create(getName(), "qupath", "qupath-extension-omero-web");
 	}
 	
 	@Override


### PR DESCRIPTION
Includes upstream https://github.com/qupath/qupath-extension-omero-web/pull/30, with a few extra changes to the build and README.

Builds should now produce and correctly archive `qupath-extension-omero-web-*.jar` artifacts, so we don't need to remember to rename the jars as part of the release process.