### PR TITLE
Tell image server to consider 3 channel uint8 data as RGB

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
@@ -313,7 +313,7 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 //				.args(args)
 				.name(imageName)
 				.pixelType(pixelType)
-				.rgb(isRGB)
+				.rgb(isRGB || (sizeC == 3 && pixelType == PixelType.UINT8))
 				.magnification(magnification)
 				.levels(levelBuilder.build());
 		


### PR DESCRIPTION
...even if the microservice is used. This affects the image types that are available, see https://qupath.readthedocs.io/en/stable/docs/starting/first_steps.html#setting-the-image-type.

If `rgb(false)` was passed, brightfield image types are never available, so workflows that rely on a brightfield image can break.

The issue and fix can be tested with any uint8 3-channel image on any server we've previously used for testing this extension. Standard `CMU-1.svs` or similar would be a suitable file to have imported.

Without this change, opening the test image via the 0.4.3-gs extension should prompt for an image type, but only allow non-brightfield types. So as in this screenshot, but with the first row of options missing:

https://qupath.readthedocs.io/en/stable/docs/starting/first_steps.html#setting-the-image-type

This is because the prompt for an image type specifically does not allow brightfield types to be selected if the image server does not identify the image as RGB:

https://github.com/qupath/qupath/blob/main/qupath-gui-fx/src/main/java/qupath/lib/gui/panes/ImageDetailsPane.java#L388

The change here tells the image server to report an image as RGB if the microservice was not used (as before) or if there are exactly 3 uint8 channels and the microservice is used. With this change, the prompt for an image type should allow all of the brightfield options to be selected (as in the linked screenshot above). I would expect no other change in behavior, as this is intended not to affect how image data is actually retrieved from OMERO.