### PR TITLE
Calculate resolution sizes based on an integer scale factor, not the zoom level

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
@@ -282,7 +282,15 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 			if (levels > 1) {
 				JsonObject zoom = map.getAsJsonObject("zoomLevelScaling");
 				for (int i = 0; i < levels; i++) {
-					levelBuilder.addLevelByDownsample(1.0 / zoom.getAsJsonPrimitive(Integer.toString(i)).getAsDouble());
+          double rawZoomFactor = zoom.getAsJsonPrimitive(Integer.toString(i)).getAsDouble();
+          int scaleFactor = (int) Math.ceil(1 / rawZoomFactor);
+          logger.debug("level = {}, rawZoomFactor = {}, scaleFactor = {}", i, rawZoomFactor, scaleFactor);
+
+          int levelWidth = sizeX / scaleFactor;
+          int levelHeight = sizeY / scaleFactor;
+          logger.debug("  level width = {}, level height = {}", levelWidth, levelHeight);
+
+          levelBuilder.addLevel(scaleFactor, levelWidth, levelHeight);
 				}
 			} else {
 				levelBuilder.addFullResolutionLevel();


### PR DESCRIPTION
Fixes #8. This scales each resolution by an integer amount, e.g. 2, 4, 8, etc. instead of directly using the zoom level returned by `imgData` which may introduce rounding errors that cause the calculated dimensions to be too large.

In addition to the synthetic data described in https://github.com/glencoesoftware/qupath-extension-omero-web/issues/8#issue-2515143501, the non-public dataset in `curated/cellsens/qa-18870/` should demonstrate the original problem and the fix.