### PR TITLE
Handle null channels in OmeroShape.getPlane

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
@@ -269,7 +269,7 @@ class OmeroShapes {
 		
 		
 		protected ImagePlane getPlane() {
-			if (c >= 0)
+			if (c!= null && c >= 0)
 				return ImagePlane.getPlaneWithChannel(c, z, t);
 			else
 				return ImagePlane.getPlane(z, t);

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
@@ -269,10 +269,12 @@ class OmeroShapes {
 		
 		
 		protected ImagePlane getPlane() {
+			int zIndex = z != null ? z.intValue() : 0;
+			int tIndex = t != null ? t.intValue() : 0;
 			if (c!= null && c >= 0)
-				return ImagePlane.getPlaneWithChannel(c, z, t);
+				return ImagePlane.getPlaneWithChannel(c, zIndex, tIndex);
 			else
-				return ImagePlane.getPlane(z, t);
+				return ImagePlane.getPlane(zIndex, tIndex);
 		}
 		
 		protected void setType(String type) {


### PR DESCRIPTION
Hopefully fixes #10 

As a consequence of defb154faedb351cbb6cc8990d3c1947cd43841d, the channels retrieved from the server should now be `Integer` objects rather than `int` which means they can be `null`.
This adjusts the `getPlane` API to handle null channels similarly to how (incorrect) values of `-1` were handled previously.