### PR TITLE
Use PathObject.setColor(...) instead of PathObject.setColorRGB(...)

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroShapes.java
@@ -262,7 +262,7 @@ class OmeroShapes {
 			if (text != null && !text.isBlank())
 				pathObject.setName(text);
 			if (strokeColor != null)
-				pathObject.setColorRGB(strokeColor >> 8);
+				pathObject.setColor(strokeColor >> 8);
 			if (locked != null)
 				pathObject.setLocked(locked);
 		}

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroTools.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroTools.java
@@ -429,7 +429,7 @@ public final class OmeroTools {
 				if (pathObject instanceof PathCellObject) {
 					var detTemp = PathObjects.createDetectionObject(pathObject.getROI());
 					detTemp.setPathClass(pathObject.getPathClass());
-					detTemp.setColorRGB(pathObject.getColorRGB());
+					detTemp.setColor(pathObject.getColor());
 					detTemp.setName(pathObject.getName());
 					pathObject = detTemp;
 				}


### PR DESCRIPTION
setColorRGB was deprecated in 0.4.0 (https://github.com/qupath/qupath/pull/1089) and removed in 0.6.0 (https://github.com/qupath/qupath/pull/1593).

Fixes #13. This is expected to work with QuPath 0.4.0 through 0.6.0, but will not work with versions prior to 0.4.0.