### PR TITLE
Detect new `resolutions` key with resolution dimensions

### DIFF
--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
@@ -280,28 +280,28 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		if (map.getAsJsonPrimitive("tiles").getAsBoolean()) {
 			int levels = map.getAsJsonPrimitive("levels").getAsInt();
 			if (levels > 1) {
-        // OMERO.web 5.31.0 and later provides explicit XY resolution sizes
-        // older versions only provide a scaling factor,
-        // which can lead to rounding errors
-        JsonObject sizes = map.getAsJsonObject("resolutions");
-        logger.debug("sizes = {}", sizes);
-        if (sizes != null) {
-          for (int i=0; i<levels; i++) {
-            JsonObject xy = sizes.getAsJsonObject(Integer.toString(i));
-            int x = xy.getAsJsonPrimitive("sizeX").getAsInt();
-            int y = xy.getAsJsonPrimitive("sizeY").getAsInt();
-            logger.debug("adding resolution level using size: {}x{}", x, y);
-            levelBuilder.addLevel(x, y);
-          }
-        }
-        else {
-          JsonObject zoom = map.getAsJsonObject("zoomLevelScaling");
-          for (int i = 0; i < levels; i++) {
-            double zoomLevel = 1.0 / zoom.getAsJsonPrimitive(Integer.toString(i)).getAsDouble();
-            logger.debug("adding resolution level using zoom level: {}", zoomLevel);
-            levelBuilder.addLevelByDownsample(zoomLevel);
-          }
-        }
+				// OMERO.web 5.31.0 and later provides explicit XY resolution sizes
+				// older versions only provide a scaling factor,
+				// which can lead to rounding errors
+				JsonObject sizes = map.getAsJsonObject("resolutions");
+				logger.debug("sizes = {}", sizes);
+				if (sizes != null) {
+					for (int i=0; i<levels; i++) {
+						JsonObject xy = sizes.getAsJsonObject(Integer.toString(i));
+						int x = xy.getAsJsonPrimitive("sizeX").getAsInt();
+						int y = xy.getAsJsonPrimitive("sizeY").getAsInt();
+						logger.debug("adding resolution level using size: {}x{}", x, y);
+						levelBuilder.addLevel(x, y);
+					}
+				}
+				else {
+					JsonObject zoom = map.getAsJsonObject("zoomLevelScaling");
+					for (int i = 0; i < levels; i++) {
+						double zoomLevel = 1.0 / zoom.getAsJsonPrimitive(Integer.toString(i)).getAsDouble();
+						logger.debug("adding resolution level using zoom level: {}", zoomLevel);
+						levelBuilder.addLevelByDownsample(zoomLevel);
+					}
+				}
 			} else {
 				levelBuilder.addFullResolutionLevel();
 			}

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
@@ -280,10 +280,28 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		if (map.getAsJsonPrimitive("tiles").getAsBoolean()) {
 			int levels = map.getAsJsonPrimitive("levels").getAsInt();
 			if (levels > 1) {
-				JsonObject zoom = map.getAsJsonObject("zoomLevelScaling");
-				for (int i = 0; i < levels; i++) {
-					levelBuilder.addLevelByDownsample(1.0 / zoom.getAsJsonPrimitive(Integer.toString(i)).getAsDouble());
-				}
+        // newer versions of OMERO provide explicit XY resolution sizes
+        // older versions only provide a scaling factor,
+        // which can lead to rounding errors
+        JsonObject sizes = map.getAsJsonObject("resolutions");
+        logger.debug("sizes = {}", sizes);
+        if (sizes != null) {
+          for (int i=0; i<levels; i++) {
+            JsonObject xy = sizes.getAsJsonObject(Integer.toString(i));
+            int x = xy.getAsJsonPrimitive("sizeX").getAsInt();
+            int y = xy.getAsJsonPrimitive("sizeY").getAsInt();
+            logger.debug("adding resolution level using size: {}x{}", x, y);
+            levelBuilder.addLevel(x, y);
+          }
+        }
+        else {
+          JsonObject zoom = map.getAsJsonObject("zoomLevelScaling");
+          for (int i = 0; i < levels; i++) {
+            double zoomLevel = 1.0 / zoom.getAsJsonPrimitive(Integer.toString(i)).getAsDouble();
+            logger.debug("adding resolution level using zoom level: {}", zoomLevel);
+            levelBuilder.addLevelByDownsample(zoomLevel);
+          }
+        }
 			} else {
 				levelBuilder.addFullResolutionLevel();
 			}

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
@@ -280,7 +280,7 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		if (map.getAsJsonPrimitive("tiles").getAsBoolean()) {
 			int levels = map.getAsJsonPrimitive("levels").getAsInt();
 			if (levels > 1) {
-        // newer versions of OMERO provide explicit XY resolution sizes
+        // OMERO.web 5.31.0 and later provides explicit XY resolution sizes
         // older versions only provide a scaling factor,
         // which can lead to rounding errors
         JsonObject sizes = map.getAsJsonObject("resolutions");


### PR DESCRIPTION
If present, use the `sizeX` and `sizeY` attributes to set the resolution dimensions without additional calculation. If the `resolutions` key is not found, fall back to the original size calculation that uses `zoomLevelScaling`.

Fixes #8.

Tested in QuPath 0.5.1 with `DEBUG`-level logging enabled using:

- the artificial test data in the description of #8, imported to a server that supports the new `resolutions` key
- `CMU-1.svs` imported to a server that does not support the `resolutions` key

In the first case, logging shows that the resolution levels were added using the retrieved XY sizes. Zooming in and out on the resulting image in QuPath does not show any issues.

In the second case, logging shows that the resolution levels were added using the zoom level, so XY sizes are calculated as before.