### PR TITLE
Add checkstyle config to enforce tab identation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
   id 'org.openjfx.javafxplugin' version '0.1.0'
   // Version in settings.gradle
   id 'org.bytedeco.gradle-javacpp-platform'
+  id 'checkstyle'
 }
 
 ext.moduleName = 'qupath.extension.omero-web'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        https://checkstyle.org/5.x/config.html#Checker
+
+        <property name="basedir" value="${basedir}"/>
+    -->
+    <property name="severity" value="error"/>
+    <property name="tabWidth" value="4"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="4"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t* "/>
+            <property name="message" value="Indent must use tab characters"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+    </module>
+
+</module>

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroAnnotations.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroAnnotations.java
@@ -77,12 +77,12 @@ final class OmeroAnnotations {
 		}
 		
 		public static OmeroAnnotationType fromString(String text) {
-	        for (var type : OmeroAnnotationType.values()) {
-	            if (type.name.equalsIgnoreCase(text) || type.urlName.equalsIgnoreCase(text))
-	                return type;
-	        }
-	        return UNKNOWN;
-	    }
+			for (var type : OmeroAnnotationType.values()) {
+				if (type.name.equalsIgnoreCase(text) || type.urlName.equalsIgnoreCase(text))
+					return type;
+			}
+			return UNKNOWN;
+		}
 		
 		public String toURLString() {
 			return urlName;

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroExtension.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroExtension.java
@@ -88,12 +88,12 @@ public class OmeroExtension implements QuPathExtension, GitHubProject {
 		
 		MenuTools.addMenuItems(qupath.getMenu("Extensions", false), 
 				MenuTools.createMenu("OMERO", 
-                		browseServerMenu,
-    	                actionClients,
-    	                null,
-    	                actionSendObjects
-    	                )
-				);
+									browseServerMenu,
+									actionClients,
+									null,
+									actionSendObjects
+				)
+		);
 		createServerListMenu(qupath, browseServerMenu);
 	}
 	
@@ -110,9 +110,9 @@ public class OmeroExtension implements QuPathExtension, GitHubProject {
 	
 	private static Menu createServerListMenu(QuPathGUI qupath, Menu browseServerMenu) {
 		EventHandler<Event> validationHandler = e -> {
-      StringProperty usedServerProp = PathPrefs.createPersistentPreference("omero_ext.server_list", "");
+			StringProperty usedServerProp = PathPrefs.createPersistentPreference("omero_ext.server_list", "");
 
-      List<String> usedServers = getServerList(usedServerProp);
+			List<String> usedServers = getServerList(usedServerProp);
 
 			browseServerMenu.getItems().clear();
 			
@@ -120,13 +120,13 @@ public class OmeroExtension implements QuPathExtension, GitHubProject {
 			var activeServers = OmeroWebClients.getAllClients();
 			
 			// Populate the menu with each unique active servers
-      ArrayList<String> activeURIs = new ArrayList<String>();
+			ArrayList<String> activeURIs = new ArrayList<String>();
 			for (var client: activeServers) {
 				if (client == null)
 					continue;
-        // 3 dots are appended to distinguish active connections
+				// 3 dots are appended to distinguish active connections
 				MenuItem item = new MenuItem(client.getServerURI() + "...");
-        activeURIs.add(client.getServerURI().toString());
+				activeURIs.add(client.getServerURI().toString());
 				item.setOnAction(e2 -> {
 					var browser = browsers.get(client);
 					if (browser == null || browser.getStage() == null) {
@@ -139,47 +139,47 @@ public class OmeroExtension implements QuPathExtension, GitHubProject {
 				browseServerMenu.getItems().add(item);
 			}
 
-      // add servers that have been connected to previously,
-      // but which are not currently connected
-      if (usedServers != null) {
-        for (String server : usedServers) {
-          final String usedServer = server.endsWith("/") ? server.substring(0, server.length() - 1) : server;
-          if (!usedServer.isEmpty() && !activeURIs.contains(usedServer)) {
-            // no suffix appended to the server name here
-            // distinguishes from active connections that have 3 dots appended
-            MenuItem item = new MenuItem(usedServer);
-            item.setOnAction(e2 -> {
-              handleLogin(qupath, usedServer);
-            });
-            browseServerMenu.getItems().add(item);
-          }
-        }
-      }
+			// add servers that have been connected to previously,
+			// but which are not currently connected
+			if (usedServers != null) {
+				for (String server : usedServers) {
+					final String usedServer = server.endsWith("/") ? server.substring(0, server.length() - 1) : server;
+					if (!usedServer.isEmpty() && !activeURIs.contains(usedServer)) {
+						// no suffix appended to the server name here
+						// distinguishes from active connections that have 3 dots appended
+						MenuItem item = new MenuItem(usedServer);
+						item.setOnAction(e2 -> {
+							handleLogin(qupath, usedServer);
+						});
+						browseServerMenu.getItems().add(item);
+					}
+				}
+			}
 			
 			// Create 'New server...' MenuItem
 			MenuItem customServerItem = new MenuItem("New server...");
 			customServerItem.setOnAction(e2 -> {
 				GridPane gp = new GridPane();
 				gp.setVgap(5.0);
-		        TextField tf = new TextField();
-		        tf.setPrefWidth(400);
-		        GridPaneUtils.addGridRow(gp, 0, 0, "Enter OMERO URL", new Label("Enter an OMERO server URL to browse (e.g. http://idr.openmicroscopy.org/):"));
+				TextField tf = new TextField();
+				tf.setPrefWidth(400);
+				GridPaneUtils.addGridRow(gp, 0, 0, "Enter OMERO URL", new Label("Enter an OMERO server URL to browse (e.g. http://idr.openmicroscopy.org/):"));
 				GridPaneUtils.addGridRow(gp, 1, 0, "Enter OMERO URL", tf, tf);
-		        var confirm = Dialogs.showConfirmDialog("Enter OMERO URL", gp);
-		        if (!confirm)
-		        	return;
-		        
-		        var path = tf.getText();
+				var confirm = Dialogs.showConfirmDialog("Enter OMERO URL", gp);
+				if (!confirm)
+					return;
+
+				var path = tf.getText();
 				if (path == null || path.isEmpty())
 					return;
 
-        handleLogin(qupath, path);
+				handleLogin(qupath, path);
 
-        List<String> serverList = getServerList(usedServerProp);
-        if (serverList != null && !serverList.contains(path)) {
-          serverList.add(path);
-          usedServerProp.setValue((new Gson()).toJson(serverList));
-        }
+				List<String> serverList = getServerList(usedServerProp);
+				if (serverList != null && !serverList.contains(path)) {
+					serverList.add(path);
+					usedServerProp.setValue((new Gson()).toJson(serverList));
+				}
 			});
 			MenuTools.addMenuItems(browseServerMenu, null, customServerItem);
 		};
@@ -189,56 +189,56 @@ public class OmeroExtension implements QuPathExtension, GitHubProject {
 		return browseServerMenu;
 	}
 
-  private static List<String> getServerList(StringProperty usedServerProp) {
-    Gson gson = new Gson();
-    List<String> usedServers = null;
-    try {
-        usedServers = gson.fromJson(usedServerProp.get(), new TypeToken<>() {});
-    } catch (JsonSyntaxException ignored) {}
-    if (usedServers == null) {
-      usedServers = new ArrayList<String>();
-    }
-    return usedServers;
-  }
+	private static List<String> getServerList(StringProperty usedServerProp) {
+		Gson gson = new Gson();
+		List<String> usedServers = null;
+		try {
+			usedServers = gson.fromJson(usedServerProp.get(), new TypeToken<>() {});
+		} catch (JsonSyntaxException ignored) {}
+		if (usedServers == null) {
+			usedServers = new ArrayList<String>();
+		}
+		return usedServers;
+	}
 
-  static void handleLogin(QuPathGUI qupath, String path) {
-    try {
-      if (!path.startsWith("http:") && !path.startsWith("https:")) {
-        throw new IOException("The input URL must contain a scheme (e.g. \"https://\")!");
-      }
-      // Make the path a URI
-      URI uri = new URI(path);
-      
-      // Clean the URI (in case it's a full path)
-      URI uriServer = OmeroTools.getServerURI(uri);
-      
-      if (uriServer == null)
-        throw new MalformedURLException("Could not parse server from " + uri.toString());
-      
-      // Check if client exist and if browser is already opened
-      var client = OmeroWebClients.getClientFromServerURI(uriServer);
-      if (client == null)
-        client = OmeroWebClients.createClientAndLogin(uriServer);
-      
-      if (client == null)
-        throw new IOException("Could not parse server from " + uri.toString());
-      
-      var browser = browsers.get(client);
-      if (browser == null || browser.getStage() == null) {
-        // Create new browser
-        browser = new OmeroWebImageServerBrowserCommand(qupath, client);
-        browsers.put(client, browser);
-        browser.run();
-      } else	// Request focus for already-existing browser
-        browser.getStage().requestFocus();		
-      
-    } catch (FileNotFoundException ex) {
-      Dialogs.showErrorMessage("OMERO web server", String.format("An error occured when trying to reach %s: %s\"", path, ex.getLocalizedMessage()));
-    } catch (IOException | URISyntaxException ex) {
-      Dialogs.showErrorMessage("OMERO web server", ex.getLocalizedMessage());
-      return;
-    }
-  }
+	static void handleLogin(QuPathGUI qupath, String path) {
+		try {
+			if (!path.startsWith("http:") && !path.startsWith("https:")) {
+				throw new IOException("The input URL must contain a scheme (e.g. \"https://\")!");
+			}
+			// Make the path a URI
+			URI uri = new URI(path);
+
+			// Clean the URI (in case it's a full path)
+			URI uriServer = OmeroTools.getServerURI(uri);
+
+			if (uriServer == null)
+				throw new MalformedURLException("Could not parse server from " + uri.toString());
+
+			// Check if client exist and if browser is already opened
+			var client = OmeroWebClients.getClientFromServerURI(uriServer);
+			if (client == null)
+				client = OmeroWebClients.createClientAndLogin(uriServer);
+			
+			if (client == null)
+				throw new IOException("Could not parse server from " + uri.toString());
+
+			var browser = browsers.get(client);
+			if (browser == null || browser.getStage() == null) {
+				// Create new browser
+				browser = new OmeroWebImageServerBrowserCommand(qupath, client);
+				browsers.put(client, browser);
+				browser.run();
+			} else	// Request focus for already-existing browser
+				browser.getStage().requestFocus();		
+
+		} catch (FileNotFoundException ex) {
+			Dialogs.showErrorMessage("OMERO web server", String.format("An error occured when trying to reach %s: %s\"", path, ex.getLocalizedMessage()));
+		} catch (IOException | URISyntaxException ex) {
+			Dialogs.showErrorMessage("OMERO web server", ex.getLocalizedMessage());
+			return;
+		}
+	}
 	
 	/**
 	 * Return map of currently opened browsers.

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroObjects.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroObjects.java
@@ -78,12 +78,12 @@ final class OmeroObjects {
 		}
 
 		static OmeroObjectType fromString(String text) {
-	        for (var type : OmeroObjectType.values()) {
-	            if (type.APIName.equalsIgnoreCase(text) || type.displayedName.equalsIgnoreCase(text))
-	                return type;
-	        }
-	        return UNKNOWN;
-	    }
+			for (var type : OmeroObjectType.values()) {
+				if (type.APIName.equalsIgnoreCase(text) || type.displayedName.equalsIgnoreCase(text))
+					return type;
+			}
+			return UNKNOWN;
+		}
 		
 		String toURLString() {
 			return displayedName.toLowerCase() + 's';
@@ -232,14 +232,14 @@ final class OmeroObjects {
 		
 		
 		@Override
-	    public int hashCode() {
-	        return Objects.hash(id);
-	    }
+		public int hashCode() {
+			return Objects.hash(id);
+		}
 
 		@Override
 		public boolean equals(Object obj) {
 			if (obj == this)
-	            return true;
+							return true;
 			
 			if (!(obj instanceof OmeroObject))
 				return false;

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroRequests.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroRequests.java
@@ -120,17 +120,17 @@ public final class OmeroRequests {
 		URL url = new URL(scheme, host, port, String.format(JSON_API_INFO, type.toURLString(), id) + (args == null ? "" : args));
 		
 		// Open connection
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        int response = connection.getResponseCode();
-        
-        // Catch bad response
-        if (response != 200)
-        	throw new IOException(String.format("Connection to %s failed: Error %d.", url.getHost(), response));
-        
-        // Read input stream
-        try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
-        	return GsonTools.getInstance().fromJson(reader, JsonObject.class);
-        }
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+		int response = connection.getResponseCode();
+		
+		// Catch bad response
+		if (response != 200)
+			throw new IOException(String.format("Connection to %s failed: Error %d.", url.getHost(), response));
+		
+		// Read input stream
+		try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
+			return GsonTools.getInstance().fromJson(reader, JsonObject.class);
+		}
 	}
 	
 	/**
@@ -151,7 +151,7 @@ public final class OmeroRequests {
 	 * @see #requestWebClientObjectList
 	 */
 	public static List<JsonElement> requestObjectList(String scheme, String host, int port, OmeroObjectType objectType) throws IOException {
-			return requestObjectList(scheme, host, port, objectType, null, -1);
+		return requestObjectList(scheme, host, port, objectType, null, -1);
 	}
 	
 	/**
@@ -275,11 +275,11 @@ public final class OmeroRequests {
 	public static JsonObject requestWebClientObjectList(String scheme, String host, int port, OmeroObjectType objectType) throws IOException {
 		URL urlOrphanedImages = new URL(scheme, host, port, String.format("/webclient/api/%s/?orphaned=true", objectType.toURLString()));
 		HttpURLConnection connection = (HttpURLConnection) urlOrphanedImages.openConnection();
-        if (connection.getResponseCode() == 200) {
-        	try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
-        		return GsonTools.getInstance().fromJson(reader, JsonObject.class);
-        	}
-        }
+		if (connection.getResponseCode() == 200) {
+			try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
+				return GsonTools.getInstance().fromJson(reader, JsonObject.class);
+			}
+		}
 		throw new IOException(String.format("Error %d while connecting to OMERO Webclient: %s", connection.getResponseCode(), connection.getResponseMessage()));
 	}
 	

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroTools.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroTools.java
@@ -227,35 +227,35 @@ public final class OmeroTools {
 		
 		try {
 			var map = OmeroRequests.requestWebClientObjectList(uri.getScheme(), uri.getHost(), uri.getPort(), OmeroObjectType.IMAGE);
-    		ExecutorService executorRequests = Executors.newSingleThreadExecutor(ThreadTools.createThreadFactory("orphaned-image-requests", true));
-    		
-    		// Get the total amount of orphaned images to load
-    		int max = map.get("images").getAsJsonArray().size();
-    		if (max == 0)
-    			orphanedFolder.setLoading(false);
-    		
-    		orphanedFolder.setTotalChildCount(max);
-    		map.get("images").getAsJsonArray().forEach(e -> {
-    			executorRequests.submit(() -> {
-    				try {
-    					var id = Integer.parseInt(e.getAsJsonObject().get("id").toString());
-    					OmeroObject omeroObj = readOmeroObject(uri.getScheme(), uri.getHost(), uri.getPort(), id, OmeroObjectType.IMAGE);
-        				Platform.runLater(() -> {
-        					list.add(omeroObj);
-        					
-        					// Check if all orphaned images were loaded
-        					if (orphanedFolder.incrementAndGetLoadedCount() >= max)
-        						orphanedFolder.setLoading(false);
-        				});
-    				} catch (IOException ex) {
+			ExecutorService executorRequests = Executors.newSingleThreadExecutor(ThreadTools.createThreadFactory("orphaned-image-requests", true));
+
+			// Get the total amount of orphaned images to load
+			int max = map.get("images").getAsJsonArray().size();
+			if (max == 0)
+				orphanedFolder.setLoading(false);
+
+			orphanedFolder.setTotalChildCount(max);
+			map.get("images").getAsJsonArray().forEach(e -> {
+				executorRequests.submit(() -> {
+					try {
+						var id = Integer.parseInt(e.getAsJsonObject().get("id").toString());
+						OmeroObject omeroObj = readOmeroObject(uri.getScheme(), uri.getHost(), uri.getPort(), id, OmeroObjectType.IMAGE);
+						Platform.runLater(() -> {
+							list.add(omeroObj);
+
+							// Check if all orphaned images were loaded
+							if (orphanedFolder.incrementAndGetLoadedCount() >= max)
+								orphanedFolder.setLoading(false);
+						});
+					} catch (IOException ex) {
 						logger.error("Could not fetch information for image id: " + e.getAsJsonObject().get("id"), ex);
 					}
-    			});
-        	});
-    		executorRequests.shutdown();
-        } catch (IOException ex) {
-        	logger.error(ex.getLocalizedMessage());
-        }
+				});
+			});
+			executorRequests.shutdown();
+		} catch (IOException ex) {
+			logger.error(ex.getLocalizedMessage());
+		}
 	}
 	
 	/**
@@ -285,36 +285,36 @@ public final class OmeroTools {
 		return list;
 	}
 	
-    /**
-     * Helper method to retrieve an {@code OmeroObject} of type {@code OmeroObjectType} with {@code id} from 
-     * a given server details. An IOException will be thrown if the connection fails.
-     * <p>
-     * N.B: this method does not set the parent object.
-     * 
-     * @param scheme
+	/**
+	 * Helper method to retrieve an {@code OmeroObject} of type {@code OmeroObjectType} with {@code id} from 
+	 * a given server details. An IOException will be thrown if the connection fails.
+	 * <p>
+	 * N.B: this method does not set the parent object.
+	 * 
+	 * @param scheme
 	 * @param host
 	 * @param port
 	 * @param id
 	 * @param type
 	 * @return OmeroObject
 	 * @throws IOException
-     */
-    public static OmeroObject readOmeroObject(String scheme, String host, int port, int id, OmeroObjectType type) throws IOException {
-    	// Request json
-    	var map = OmeroRequests.requestObjectInfo(scheme, host, port, id, type);
-        
-        // Create OmeroObject
-        var gson = new GsonBuilder().registerTypeAdapter(OmeroObject.class, new OmeroObjects.GsonOmeroObjectDeserializer()).setLenient().create();
-        return gson.fromJson(map.get("data").getAsJsonObject(), OmeroObject.class);
-    }
-    
-    /**
+	 */
+	public static OmeroObject readOmeroObject(String scheme, String host, int port, int id, OmeroObjectType type) throws IOException {
+		// Request json
+		var map = OmeroRequests.requestObjectInfo(scheme, host, port, id, type);
+
+		// Create OmeroObject
+		var gson = new GsonBuilder().registerTypeAdapter(OmeroObject.class, new OmeroObjects.GsonOmeroObjectDeserializer()).setLenient().create();
+		return gson.fromJson(map.get("data").getAsJsonObject(), OmeroObject.class);
+	}
+
+	/**
 	 * Return the Id associated with the {@code URI} provided.
 	 * If multiple Ids are present, only the first one will be retrieved.
 	 * If no Id could be found, return -1.
 	 * 
 	 * @param uri
-     * @param type 
+	 * @param type 
 	 * @return Id
 	 */
 	public static int parseOmeroObjectId(URI uri, OmeroObjectType type) {
@@ -344,7 +344,7 @@ public final class OmeroTools {
 		return -1;
 	}
 	
-    /**
+	/**
 	 * Return the type associated with the {@code URI} provided.
 	 * If multiple types are present, only the first one will be retrieved.
 	 * If no type is found, return UNKNOWN.
@@ -357,18 +357,18 @@ public final class OmeroTools {
 	 * @return omeroObjectType
 	 */
 	public static OmeroObjectType parseOmeroObjectType(URI uri) {
-			var uriString = uri.toString().replace("%3D", "=");
-	        if (patternLinkProject.matcher(uriString).find())
-	        	return OmeroObjectType.PROJECT;
-	        else if (patternLinkDataset.matcher(uriString).find())
-	        	return OmeroObjectType.DATASET;
-	        else {
-	        	for (var p: imagePatterns) {
-	        		if (p.matcher(uriString).find())
-	        			return OmeroObjectType.IMAGE;
-	        	}
-	        }
-	        return OmeroObjectType.UNKNOWN;
+		var uriString = uri.toString().replace("%3D", "=");
+		if (patternLinkProject.matcher(uriString).find())
+			return OmeroObjectType.PROJECT;
+		else if (patternLinkDataset.matcher(uriString).find())
+			return OmeroObjectType.DATASET;
+		else {
+			for (var p: imagePatterns) {
+				if (p.matcher(uriString).find())
+					return OmeroObjectType.IMAGE;
+			}
+		}
+		return OmeroObjectType.UNKNOWN;
 	}
 	
 	
@@ -530,50 +530,50 @@ public final class OmeroTools {
 	}
 	
 	
-    /**
-     * OMERO requests that return a list of items are paginated 
-     * (see <a href="https://docs.openmicroscopy.org/omero/5.6.1/developers/json-api.html#pagination">OMERO API docs</a>).
-     * Using this helper method ensures that all the requested data is retrieved.
-     * 
-     * @param url
-     * @return list of {@code Json Element}s
-     * @throws IOException
-     */
+	/**
+	 * OMERO requests that return a list of items are paginated 
+	 * (see <a href="https://docs.openmicroscopy.org/omero/5.6.1/developers/json-api.html#pagination">OMERO API docs</a>).
+	 * Using this helper method ensures that all the requested data is retrieved.
+	 * 
+	 * @param url
+	 * @return list of {@code Json Element}s
+	 * @throws IOException
+	 */
 	// TODO: Consider using parallel/asynchronous requests
-    static List<JsonElement> readPaginated(URL url) throws IOException {
-    	List<JsonElement> jsonList = new ArrayList<>();
-        String symbol = (url.getQuery() != null && !url.getQuery().isEmpty()) ? "&" : "?";
+	static List<JsonElement> readPaginated(URL url) throws IOException {
+		List<JsonElement> jsonList = new ArrayList<>();
+		String symbol = (url.getQuery() != null && !url.getQuery().isEmpty()) ? "&" : "?";
 
-        // Open connection
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        int response = connection.getResponseCode();
-        
-        // Catch bad response
-        if (response != 200)
-        	return jsonList;
+		// Open connection
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+		int response = connection.getResponseCode();
 
-        JsonObject map;
-        try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
-        	map = GsonTools.getInstance().fromJson(reader, JsonObject.class);
-        }
+		// Catch bad response
+		if (response != 200)
+			return jsonList;
 
-        map.get("data").getAsJsonArray().forEach(jsonList::add);
-    	JsonObject meta = map.getAsJsonObject("meta");
-        int offset = 0;
-        int totalCount = meta.get("totalCount").getAsInt();
-        int limit = meta.get("limit").getAsInt();
-        while (offset + limit < totalCount) {
-            offset += limit;
-            URL nextURL = new URL(url + symbol + "offset=" + offset);
-            InputStreamReader newPageReader = new InputStreamReader(nextURL.openStream());
-            JsonObject newPageMap = GsonTools.getInstance().fromJson(newPageReader, JsonObject.class);
-            newPageMap.get("data").getAsJsonArray().forEach(jsonList::add);
-        }
-        return jsonList;
-    }
-   
-    
-    /**
+		JsonObject map;
+		try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
+			map = GsonTools.getInstance().fromJson(reader, JsonObject.class);
+		}
+
+		map.get("data").getAsJsonArray().forEach(jsonList::add);
+		JsonObject meta = map.getAsJsonObject("meta");
+		int offset = 0;
+		int totalCount = meta.get("totalCount").getAsInt();
+		int limit = meta.get("limit").getAsInt();
+		while (offset + limit < totalCount) {
+			offset += limit;
+			URL nextURL = new URL(url + symbol + "offset=" + offset);
+			InputStreamReader newPageReader = new InputStreamReader(nextURL.openStream());
+			JsonObject newPageMap = GsonTools.getInstance().fromJson(newPageReader, JsonObject.class);
+			newPageMap.get("data").getAsJsonArray().forEach(jsonList::add);
+		}
+		return jsonList;
+	}
+
+
+	/**
 	 * Return a list of valid URIs from the given URI. If no valid URI can be parsed 
 	 * from it, an IOException is thrown.
 	 * <p>
@@ -584,125 +584,125 @@ public final class OmeroTools {
 	 * @return list
 	 * @throws IOException
 	 */
-    static List<URI> getURIs(URI uri) throws IOException {
+	static List<URI> getURIs(URI uri) throws IOException {
 		List<URI> list = new ArrayList<>();
 		URI cleanServerUri = URI.create(uri.toString().replace("show%3Dimage-", "show=image-"));
-        String elemId = "image-";
-        String query = cleanServerUri.getQuery() != null ? uri.getQuery() : "";
-        String shortPath = cleanServerUri.getPath() + query;
-        
-        Pattern[] similarPatterns = new Pattern[] {patternOldViewer, patternNewViewer, patternWebViewer};
+		String elemId = "image-";
+		String query = cleanServerUri.getQuery() != null ? uri.getQuery() : "";
+		String shortPath = cleanServerUri.getPath() + query;
 
-        // Check for simpler patterns first
-        for (int i = 0; i < similarPatterns.length; i++) {
-        	var matcher = similarPatterns[i].matcher(shortPath);
-            if (matcher.find()) {
-                elemId += matcher.group(1);
-                
-                try {
+		Pattern[] similarPatterns = new Pattern[] {patternOldViewer, patternNewViewer, patternWebViewer};
+
+		// Check for simpler patterns first
+		for (int i = 0; i < similarPatterns.length; i++) {
+			var matcher = similarPatterns[i].matcher(shortPath);
+			if (matcher.find()) {
+				elemId += matcher.group(1);
+
+				try {
 					list.add(new URL(cleanServerUri.getScheme(), cleanServerUri.getHost(), cleanServerUri.getPort(), "/webclient/?show=" + elemId).toURI());
 				} catch (MalformedURLException | URISyntaxException ex) {
 					logger.warn(ex.getLocalizedMessage());
 				}
-                return list;
-            }
-        }
+				return list;
+			}
+		}
 
-        // If no simple pattern was matched, check for the last possible one: /webclient/?show=
-        if (shortPath.startsWith("/webclient/show")) {
-        	URI newURI = getStandardURI(uri);
-            var patternElem = Pattern.compile("image-(\\d+)");
-            var matcherElem = patternElem.matcher(newURI.toString());
-            while (matcherElem.find()) {
-                list.add(URI.create(String.format("%s://%s%s%s%s%s", 
-                		uri.getScheme(), 
-                		uri.getHost(),
-                		uri.getPort() >= 0 ? ":" + uri.getPort() : "", 
-                		uri.getPath(), 
-                		"?show=image-", 
-                		matcherElem.group(1))));
-            }
-        	return list;
-        }
-        
-        // At this point, no valid URI pattern was found
-        throw new IOException("URI not recognized: " + uri.toString());
+		// If no simple pattern was matched, check for the last possible one: /webclient/?show=
+		if (shortPath.startsWith("/webclient/show")) {
+			URI newURI = getStandardURI(uri);
+			var patternElem = Pattern.compile("image-(\\d+)");
+			var matcherElem = patternElem.matcher(newURI.toString());
+			while (matcherElem.find()) {
+				list.add(URI.create(String.format("%s://%s%s%s%s%s", 
+						uri.getScheme(), 
+						uri.getHost(),
+						uri.getPort() >= 0 ? ":" + uri.getPort() : "", 
+						uri.getPath(), 
+						"?show=image-", 
+						matcherElem.group(1))));
+			}
+			return list;
+		}
+		
+		// At this point, no valid URI pattern was found
+		throw new IOException("URI not recognized: " + uri.toString());
 	}
 	
-    static URI getStandardURI(URI uri) throws IOException {
+	static URI getStandardURI(URI uri) throws IOException {
 		List<String> ids = new ArrayList<>();
 		String vertBarSign = "%7C";
 		
 		// Identify the type of element shown (e.g. dataset)
 		OmeroObjectType type;
-        String query = uri.getQuery() != null ? uri.getQuery() : "";
-        
-        // Because of encoding, the equal sign might not be recognized when loading .qpproj file
-        query = query.replace("%3D", "=");
-        
-        // Match 
-        var matcherType = patternType.matcher(query);
-        if (matcherType.find())
-            type = OmeroObjectType.fromString(matcherType.group(1).replace("-", ""));
-        else
-            throw new IOException("URI not recognized: " + uri.toString());
-        
-        var patternId = Pattern.compile(type.toString().toLowerCase() + "-(\\d+)");
-        var matcherId = patternId.matcher(query);
-        while (matcherId.find()) {
-        	ids.add(matcherId.group(1));
-        }
+		String query = uri.getQuery() != null ? uri.getQuery() : "";
 		
-        // Cascading the types to get all ('leaf') images
-        StringBuilder sb = new StringBuilder(
-        		String.format("%s://%s%s%s%s",
-	        		uri.getScheme(), 
-	        		uri.getHost(), 
-	        		uri.getPort() >= 0 ? ":" + uri.getPort() : "", 
-	        		uri.getPath(), 
-	        		"?show=image-"));
-        
-        List<String> tempIds = new ArrayList<>();
-        // TODO: Support screen and plates
-        switch (type) {
-        case SCREEN:
-        case PLATE:
-        case WELL:
-        	break;
-        case PROJECT:
-        	for (String id: ids) {
-        		var data = OmeroRequests.requestObjectList(uri.getScheme(), uri.getHost(), uri.getPort(), OmeroObjectType.DATASET, Integer.parseInt(id));
-    			for (int i = 0; i < data.size(); i++) {
-        			tempIds.add(data.get(i).getAsJsonObject().get("@id").getAsString());
-        		}
-        	}
-        	ids =  new ArrayList<>(tempIds);
-        	tempIds.clear();
-        	type = OmeroObjectType.DATASET;
-        	
-        case DATASET:
-        	for (String id: ids) {
-        		var data = OmeroRequests.requestObjectList(uri.getScheme(), uri.getHost(), uri.getPort(), OmeroObjectType.IMAGE, Integer.parseInt(id));
-    			for (int i = 0; i < data.size(); i++) {
-    				tempIds.add(data.get(i).getAsJsonObject().get("@id").getAsString());
-    			}	
-        	}
-        	ids = new ArrayList<>(tempIds);
-        	tempIds.clear();
-        	type = OmeroObjectType.IMAGE;
-        	
-        case IMAGE:
-        	if (ids.isEmpty())
-        		logger.info("No image found in URI: " + uri.toString());
-        	for (int i = 0; i < ids.size(); i++) {
-        		String imgId = (i == ids.size()-1) ? ids.get(i) : ids.get(i) + vertBarSign + "image-";
-        		sb.append(imgId);
-        	}
-        	break;
-        default:
-        	throw new IOException("No image found in URI: " + uri.toString());
-        }
-        
+		// Because of encoding, the equal sign might not be recognized when loading .qpproj file
+		query = query.replace("%3D", "=");
+		
+		// Match 
+		var matcherType = patternType.matcher(query);
+		if (matcherType.find())
+			type = OmeroObjectType.fromString(matcherType.group(1).replace("-", ""));
+		else
+			throw new IOException("URI not recognized: " + uri.toString());
+		
+		var patternId = Pattern.compile(type.toString().toLowerCase() + "-(\\d+)");
+		var matcherId = patternId.matcher(query);
+		while (matcherId.find()) {
+			ids.add(matcherId.group(1));
+		}
+		
+		// Cascading the types to get all ('leaf') images
+		StringBuilder sb = new StringBuilder(
+				String.format("%s://%s%s%s%s",
+					uri.getScheme(), 
+					uri.getHost(), 
+					uri.getPort() >= 0 ? ":" + uri.getPort() : "", 
+					uri.getPath(), 
+					"?show=image-"));
+		
+		List<String> tempIds = new ArrayList<>();
+		// TODO: Support screen and plates
+		switch (type) {
+			case SCREEN:
+			case PLATE:
+			case WELL:
+				break;
+			case PROJECT:
+				for (String id: ids) {
+					var data = OmeroRequests.requestObjectList(uri.getScheme(), uri.getHost(), uri.getPort(), OmeroObjectType.DATASET, Integer.parseInt(id));
+					for (int i = 0; i < data.size(); i++) {
+						tempIds.add(data.get(i).getAsJsonObject().get("@id").getAsString());
+					}
+				}
+				ids =  new ArrayList<>(tempIds);
+				tempIds.clear();
+				type = OmeroObjectType.DATASET;
+				
+			case DATASET:
+				for (String id: ids) {
+					var data = OmeroRequests.requestObjectList(uri.getScheme(), uri.getHost(), uri.getPort(), OmeroObjectType.IMAGE, Integer.parseInt(id));
+					for (int i = 0; i < data.size(); i++) {
+						tempIds.add(data.get(i).getAsJsonObject().get("@id").getAsString());
+					}	
+				}
+				ids = new ArrayList<>(tempIds);
+				tempIds.clear();
+				type = OmeroObjectType.IMAGE;
+				
+			case IMAGE:
+				if (ids.isEmpty())
+					logger.info("No image found in URI: " + uri.toString());
+				for (int i = 0; i < ids.size(); i++) {
+					String imgId = (i == ids.size()-1) ? ids.get(i) : ids.get(i) + vertBarSign + "image-";
+					sb.append(imgId);
+				}
+				break;
+			default:
+				throw new IOException("No image found in URI: " + uri.toString());
+		}
+		
 		return URI.create(sb.toString());
 	}
 }

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebClient.java
@@ -120,8 +120,8 @@ public class OmeroWebClient {
 	 */
 	private int userId;
 
-  private String sessionId;
-  private boolean hasMicroservice = false;
+	private String sessionId;
+	private boolean hasMicroservice = false;
 	
 	/**
 	 * Logged in property (modified by login/loggedIn/logout/timer)
@@ -228,57 +228,57 @@ public class OmeroWebClient {
 //				e.printStackTrace();
 //			}
 
-    String rtn = null;
+		String rtn = null;
 		try (InputStream input = connection.getInputStream()) {
 			rtn = GeneralTools.readInputStreamAsString(input);
 		}
 
-    // look for session ID in existing session cookies
-    // this will throw an IOException if the 'sessionid' cookie is not found
-    // the session ID is used later when retrieving raw tiles from the microservice
-    sessionId = null;
-    List<HttpCookie> cookies = ((CookieManager) handler).getCookieStore().getCookies();
-    for (HttpCookie cookie : cookies) {
-      if (cookie.getName().equals("sessionid")) {
-        sessionId = cookie.getValue();
-      }
-    }
-    if (sessionId == null) {
-      throw new IOException("Could not find valid 'sessionid' cookie");
-    }
+		// look for session ID in existing session cookies
+		// this will throw an IOException if the 'sessionid' cookie is not found
+		// the session ID is used later when retrieving raw tiles from the microservice
+		sessionId = null;
+		List<HttpCookie> cookies = ((CookieManager) handler).getCookieStore().getCookies();
+		for (HttpCookie cookie : cookies) {
+			if (cookie.getName().equals("sessionid")) {
+				sessionId = cookie.getValue();
+			}
+		}
+		if (sessionId == null) {
+			throw new IOException("Could not find valid 'sessionid' cookie");
+		}
 
-    // check for image region microservice - enables raw tile retrieval
-    // see https://github.com/glencoesoftware/omero-ms-image-region
-    //
-    // the session ID retrieved above is not required to perform this check,
-    // but both the session ID and microservice configuration must be present in order
-    // to retrieve raw tiles
-    HttpURLConnection conn = null;
-    try {
-      URL optionsURL = new URL(serverURI.getScheme(), serverURI.getHost(), serverURI.getPort(), "/tile/");
-      conn = (HttpURLConnection) optionsURL.openConnection();
-      conn.setRequestMethod("OPTIONS");
-      conn.connect();
-      int response = conn.getResponseCode();
-      if (response == HttpURLConnection.HTTP_OK) {
-        try (InputStreamReader reader = new InputStreamReader(conn.getInputStream())) {
-          JsonObject root = GsonTools.getInstance().fromJson(reader, JsonObject.class);
-          JsonPrimitive provider = root.getAsJsonPrimitive("provider");
-          if (provider != null && provider.getAsString().equals("PixelBufferMicroservice")) {
-            hasMicroservice = true;
-          }
-        }
-      }
-      else {
-        logger.error("Could not check for OMERO microservice ({})", response);
-        hasMicroservice = false;
-      }
-    }
-    finally {
-      conn.disconnect();
-    }
+		// check for image region microservice - enables raw tile retrieval
+		// see https://github.com/glencoesoftware/omero-ms-image-region
+		//
+		// the session ID retrieved above is not required to perform this check,
+		// but both the session ID and microservice configuration must be present in order
+		// to retrieve raw tiles
+		HttpURLConnection conn = null;
+		try {
+			URL optionsURL = new URL(serverURI.getScheme(), serverURI.getHost(), serverURI.getPort(), "/tile/");
+			conn = (HttpURLConnection) optionsURL.openConnection();
+			conn.setRequestMethod("OPTIONS");
+			conn.connect();
+			int response = conn.getResponseCode();
+			if (response == HttpURLConnection.HTTP_OK) {
+				try (InputStreamReader reader = new InputStreamReader(conn.getInputStream())) {
+					JsonObject root = GsonTools.getInstance().fromJson(reader, JsonObject.class);
+					JsonPrimitive provider = root.getAsJsonPrimitive("provider");
+					if (provider != null && provider.getAsString().equals("PixelBufferMicroservice")) {
+						hasMicroservice = true;
+					}
+				}
+			}
+			else {
+				logger.error("Could not check for OMERO microservice ({})", response);
+				hasMicroservice = false;
+			}
+		}
+		finally {
+			conn.disconnect();
+		}
 
-    return rtn;
+		return rtn;
 	}
 
 	private int keepAlive() {
@@ -319,16 +319,16 @@ public class OmeroWebClient {
 			// Implementing this as a switch because of future plates/wells/.. implementations
 			String query;
 			switch (type) {
-			case PROJECT:
-			case DATASET:
-			case IMAGE:
-				query = String.format("/api/v0/m/%s/", type.toURLString());
-				break;
-			case ORPHANED_FOLDER:
-			case UNKNOWN:
-				throw new IllegalArgumentException();
-			default:
-				throw new OperationNotSupportedException("Type not supported: " + type);
+				case PROJECT:
+				case DATASET:
+				case IMAGE:
+					query = String.format("/api/v0/m/%s/", type.toURLString());
+					break;
+				case ORPHANED_FOLDER:
+				case UNKNOWN:
+					throw new IllegalArgumentException();
+				default:
+					throw new OperationNotSupportedException("Type not supported: " + type);
 			}	
 			
 			URL url = new URL(uri.getScheme(), uri.getHost(), uri.getPort(), query + id);
@@ -366,13 +366,13 @@ public class OmeroWebClient {
 		return userId;
 	}
 
-  String getSessionId() {
-    return sessionId;
-  }
+	String getSessionId() {
+		return sessionId;
+	}
 
-  boolean hasMicroservice() {
-    return hasMicroservice;
-  }
+	boolean hasMicroservice() {
+		return hasMicroservice;
+	}
 
 	void setUsername(String newUsername) {
 		username.set(newUsername);
@@ -569,7 +569,7 @@ public class OmeroWebClient {
 	@Override
 	public boolean equals(Object obj) {
 		if (obj == this)
-            return true;
+			return true;
 		
 		if (!(obj instanceof OmeroWebClient))
 			return false;

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebClientsCommand.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebClientsCommand.java
@@ -94,17 +94,17 @@ public class OmeroWebClientsCommand implements Runnable {
 			
 			// If a change is detected in the clients list, refresh pane
 			OmeroWebClients.getAllClients().addListener(new ListChangeListener<OmeroWebClient>() {
-			    @Override
-			    public void onChanged(Change<? extends OmeroWebClient> c) {
-			    	if (dialog == null)
-			    		return;
+					@Override
+					public void onChanged(Change<? extends OmeroWebClient> c) {
+						if (dialog == null)
+							return;
 
-			    	// If 'import-project' thread ('Open URI..'), 'Not on FX appl. thread' Exception can be thrown
-			    	Platform.runLater(() -> {
-			    		refreshServerGrid();
-			    		dialog.getScene().getWindow().sizeToScene();
-			    	});
-			    }
+						// If 'import-project' thread ('Open URI..'), 'Not on FX appl. thread' Exception can be thrown
+						Platform.runLater(() -> {
+							refreshServerGrid();
+							dialog.getScene().getWindow().sizeToScene();
+						});
+					}
 			});
 			
 			refreshServerGrid();

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServer.java
@@ -198,24 +198,24 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		double zSpacingMicrons = Double.NaN;
 		PixelType pixelType = PixelType.UINT8;
 
-    // if the image region microservice is used to fetch tiles,
-    // each tile will be a single (non-RGB) channel
-    // if the microservice is not available and webgateway is used instead,
-    // then only 8-bit RGB data is supported and RGB tiles will be provided
-    // see readRenderedTile and OmeroWebImageServerBrowserCommand#isSupported
+		// if the image region microservice is used to fetch tiles,
+		// each tile will be a single (non-RGB) channel
+		// if the microservice is not available and webgateway is used instead,
+		// then only 8-bit RGB data is supported and RGB tiles will be provided
+		// see readRenderedTile and OmeroWebImageServerBrowserCommand#isSupported
 		boolean isRGB = !client.hasMicroservice();
 		double magnification = Double.NaN;
 		
 		JsonObject map = OmeroRequests.requestMetadata(scheme, host, port, Integer.parseInt(id));
 		JsonObject size = map.getAsJsonObject("size");
-    JsonObject meta = map.getAsJsonObject("meta");
+		JsonObject meta = map.getAsJsonObject("meta");
 
 		sizeX = size.getAsJsonPrimitive("width").getAsInt();
 		sizeY = size.getAsJsonPrimitive("height").getAsInt();
 		sizeC = size.getAsJsonPrimitive("c").getAsInt();
 		sizeZ = size.getAsJsonPrimitive("z").getAsInt();
 		sizeT = size.getAsJsonPrimitive("t").getAsInt();
-    pixelType = convertPixelType(meta.getAsJsonPrimitive("pixelsType").getAsString());
+		pixelType = convertPixelType(meta.getAsJsonPrimitive("pixelsType").getAsString());
 
 		JsonElement pixelSizeElement = map.get("pixel_size");
 		if (pixelSizeElement != null) {
@@ -233,47 +233,47 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 			}
 		}
 
-    if (meta.has("imageName")) {
-      imageName = meta.get("imageName").getAsString();
+		if (meta.has("imageName")) {
+			imageName = meta.get("imageName").getAsString();
 		}
 
-    // copy channel names and colors from OMERO metadata
-    List<ImageChannel> channels = null;
-    if (!client.hasMicroservice()) {
-      if (sizeC == 3) {
-        channels = ImageChannel.getDefaultRGBChannels();
-      }
-      if (channels == null || pixelType != PixelType.UINT8) {
-        throw new IOException("Only 8-bit RGB images supported! Selected image has " + sizeC + " channel(s) & pixel type " + pixelType);
-      }
-    }
-    else if (map.has("channels")) {
-      channels = new ArrayList<ImageChannel>();
-      JsonArray allChannels = map.get("channels").getAsJsonArray();
+		// copy channel names and colors from OMERO metadata
+		List<ImageChannel> channels = null;
+		if (!client.hasMicroservice()) {
+			if (sizeC == 3) {
+				channels = ImageChannel.getDefaultRGBChannels();
+			}
+			if (channels == null || pixelType != PixelType.UINT8) {
+				throw new IOException("Only 8-bit RGB images supported! Selected image has " + sizeC + " channel(s) & pixel type " + pixelType);
+			}
+		}
+		else if (map.has("channels")) {
+			channels = new ArrayList<ImageChannel>();
+			JsonArray allChannels = map.get("channels").getAsJsonArray();
 
-      for (int index=0; index<allChannels.size(); index++) {
-        JsonObject channelMap = allChannels.get(index).getAsJsonObject();
-        String channelName = channelMap.getAsJsonPrimitive("label").getAsString();
-        String color = channelMap.getAsJsonPrimitive("color").getAsString();
-        Integer parsedColor = null;
+			for (int index=0; index<allChannels.size(); index++) {
+				JsonObject channelMap = allChannels.get(index).getAsJsonObject();
+				String channelName = channelMap.getAsJsonPrimitive("label").getAsString();
+				String color = channelMap.getAsJsonPrimitive("color").getAsString();
+				Integer parsedColor = null;
 
-        if (channelName == null || channelName.isEmpty()) {
-          channelName = "Channel " + (index + 1);
-        }
-        if (color == null || color.isEmpty()) {
-          parsedColor = ImageChannel.getDefaultChannelColor(index);
-        }
-        else {
-          parsedColor = Integer.parseInt(color, 16);
-        }
+				if (channelName == null || channelName.isEmpty()) {
+					channelName = "Channel " + (index + 1);
+				}
+				if (color == null || color.isEmpty()) {
+					parsedColor = ImageChannel.getDefaultChannelColor(index);
+				}
+				else {
+					parsedColor = Integer.parseInt(color, 16);
+				}
 
-        ImageChannel channel = ImageChannel.getInstance(channelName, parsedColor);
-        channels.add(channel);
-      }
-    }
-    else {
+				ImageChannel channel = ImageChannel.getInstance(channelName, parsedColor);
+				channels.add(channel);
+			}
+		}
+		else {
 			channels = ImageChannel.getDefaultChannelList(sizeC);
-    }
+		}
 	
 		var levelBuilder = new ImageServerMetadata.ImageResolutionLevel.Builder(sizeX, sizeY);
 		
@@ -291,8 +291,8 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 			if (map.has("tile_size")) {
 				JsonObject tileSizeJson = map.getAsJsonObject("tile_size");
 				tileSize = new int[]{
-						(int)tileSizeJson.getAsJsonPrimitive("width").getAsDouble(),
-						(int)tileSizeJson.getAsJsonPrimitive("height").getAsDouble()
+					(int)tileSizeJson.getAsJsonPrimitive("width").getAsDouble(),
+					(int)tileSizeJson.getAsJsonPrimitive("height").getAsDouble()
 				};
 			} else {
 				tileSize = new int[] {sizeX, sizeY};
@@ -388,10 +388,10 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		return originalMetadata;
 	}
 
-  /**
-   * Retrieve a rendered tile from webgateway.
-   */
-  protected BufferedImage readRenderedTile(TileRequest request) throws IOException {
+	/**
+	 * Retrieve a rendered tile from webgateway.
+	 */
+	protected BufferedImage readRenderedTile(TileRequest request) throws IOException {
 		int level = request.getLevel();
 
 		int targetWidth = request.getTileWidth();
@@ -465,102 +465,102 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 		BufferedImage img = ImageIO.read(url);
 
 		return BufferedImageTools.resize(img, targetWidth, targetHeight, allowSmoothInterpolation());
-  }
+	}
 
 	@Override
 	protected BufferedImage readTile(TileRequest request) throws IOException {
-    if (!client.hasMicroservice()) {
-      return readRenderedTile(request);
-    }
+		if (!client.hasMicroservice()) {
+			return readRenderedTile(request);
+		}
 
-    // calculate the resolution index to pass to OMERO
-    // the requested level matches Bio-Formats indexing,
-    // but OMERO expects resolutions to be specified in reverse order
-    int level = getMetadata().nLevels() - request.getLevel() - 1;
+		// calculate the resolution index to pass to OMERO
+		// the requested level matches Bio-Formats indexing,
+		// but OMERO expects resolutions to be specified in reverse order
+		int level = getMetadata().nLevels() - request.getLevel() - 1;
 
-    int x = request.getTileX();
-    int y = request.getTileY();
+		int x = request.getTileX();
+		int y = request.getTileY();
 		int width = request.getTileWidth();
 		int height = request.getTileHeight();
 
-    // BufferedImage creation adapted from qupath.lib.images.servers.bioformats.BioFormatsImageServer
+		// BufferedImage creation adapted from qupath.lib.images.servers.bioformats.BioFormatsImageServer
 
-    Object[] pixels = new Object[nChannels()];
+		Object[] pixels = new Object[nChannels()];
 
-    for (int c=0; c<nChannels(); c++) {
-      String urlFile = "/tile/" + id + "/" + request.getZ() + "/" + c + "/" + request.getT() +
-        "?x=" + x + "&y=" + y + "&w=" + width + "&h=" + height +
-        "&format=tif&resolution=" + level;
+		for (int c=0; c<nChannels(); c++) {
+			String urlFile = "/tile/" + id + "/" + request.getZ() + "/" + c + "/" + request.getT() +
+				"?x=" + x + "&y=" + y + "&w=" + width + "&h=" + height +
+				"&format=tif&resolution=" + level;
 
-      URL url = new URL("https", host, urlFile);
-      URLConnection conn = url.openConnection();
-      conn.setRequestProperty("Cookie", "sessionid=" + getWebclient().getSessionId());
-      conn.connect();
+			URL url = new URL("https", host, urlFile);
+			URLConnection conn = url.openConnection();
+			conn.setRequestProperty("Cookie", "sessionid=" + getWebclient().getSessionId());
+			conn.connect();
 
-      BufferedImage img = ImageIO.read(conn.getInputStream());
+			BufferedImage img = ImageIO.read(conn.getInputStream());
 
-      if (nChannels() == 1) {
-        return img;
-      }
+			if (nChannels() == 1) {
+				return img;
+			}
 
-      pixels[c] = AWTImageTools.getPixels(img);
-    }
+			pixels[c] = AWTImageTools.getPixels(img);
+		}
 
-    DataBuffer dataBuffer;
-    PixelType pixelType = getPixelType();
-    switch (pixelType) {
+		DataBuffer dataBuffer;
+		PixelType pixelType = getPixelType();
+		switch (pixelType) {
 			case UINT8:
-        byte[][] bytes = new byte[pixels.length][];
-        for (int c=0; c<bytes.length; c++) {
-          bytes[c] = ((byte[][]) pixels[c])[0];
-        }
+				byte[][] bytes = new byte[pixels.length][];
+				for (int c=0; c<bytes.length; c++) {
+					bytes[c] = ((byte[][]) pixels[c])[0];
+				}
 				dataBuffer = new DataBufferByte(bytes, bytes[0].length);
-        break;
+				break;
 			case UINT16:
 				short[][] shortArray = new short[pixels.length][];
-        for (int c=0; c<shortArray.length; c++) {
-          shortArray[c] = ((short[][]) pixels[c])[0];
+				for (int c=0; c<shortArray.length; c++) {
+					shortArray[c] = ((short[][]) pixels[c])[0];
 				}
 				dataBuffer = new DataBufferUShort(shortArray, shortArray[0].length);
 				break;
 			case INT16:
 				short[][] sshortArray = new short[pixels.length][];
-        for (int c=0; c<sshortArray.length; c++) {
-          sshortArray[c] = ((short[][]) pixels[c])[0];
+				for (int c=0; c<sshortArray.length; c++) {
+					sshortArray[c] = ((short[][]) pixels[c])[0];
 				}
 				dataBuffer = new DataBufferShort(sshortArray, sshortArray[0].length);
 				break;
 			case INT32:
 				int[][] intArray = new int[pixels.length][];
-        for (int c=0; c<intArray.length; c++) {
-          intArray[c] = ((int[][]) pixels[c])[0];
+				for (int c=0; c<intArray.length; c++) {
+					intArray[c] = ((int[][]) pixels[c])[0];
 				}
 				dataBuffer = new DataBufferInt(intArray, intArray[0].length);
 				break;
 			case FLOAT32:
 				float[][] floatArray = new float[pixels.length][];
-        for (int c=0; c<floatArray.length; c++) {
-          floatArray[c] = ((float[][]) pixels[c])[0];
+				for (int c=0; c<floatArray.length; c++) {
+					floatArray[c] = ((float[][]) pixels[c])[0];
 				}
 				dataBuffer = new DataBufferFloat(floatArray, floatArray[0].length);
 				break;
 			case FLOAT64:
 				double[][] doubleArray = new double[pixels.length][];
-        for (int c=0; c<doubleArray.length; c++) {
-          doubleArray[c] = ((double[][]) pixels[c])[0];
+				for (int c=0; c<doubleArray.length; c++) {
+					doubleArray[c] = ((double[][]) pixels[c])[0];
 				}
 				dataBuffer = new DataBufferDouble(doubleArray, doubleArray[0].length);
 				break;
 			default:
 				throw new UnsupportedOperationException("Unsupported pixel type " + pixelType);
-    }
+		}
 
-    List<ImageChannel> channels = getMetadata().getChannels();
-    ColorModel colorModel = ColorModelFactory.createColorModel(pixelType, channels);
-    SampleModel sampleModel = sampleModel = new BandedSampleModel(dataBuffer.getDataType(), width, height, channels.size());
-    WritableRaster raster = WritableRaster.createWritableRaster(sampleModel, dataBuffer, null);
-    return new BufferedImage(colorModel, raster, false, null);
-  }
+		List<ImageChannel> channels = getMetadata().getChannels();
+		ColorModel colorModel = ColorModelFactory.createColorModel(pixelType, channels);
+		SampleModel sampleModel = sampleModel = new BandedSampleModel(dataBuffer.getDataType(), width, height, channels.size());
+		WritableRaster raster = WritableRaster.createWritableRaster(sampleModel, dataBuffer, null);
+		return new BufferedImage(colorModel, raster, false, null);
+	}
 	
 	
 	@Override
@@ -637,7 +637,7 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 	@Override
 	public boolean equals(Object obj) {
 		if (obj == this)
-            return true;
+			return true;
 		
 		if (!(obj instanceof OmeroWebImageServer))
 			return false;
@@ -646,25 +646,25 @@ public class OmeroWebImageServer extends AbstractTileableImageServer implements 
 				client.getUsername().equals(((OmeroWebImageServer)obj).getWebclient().getUsername());
 	}
 
-  private PixelType convertPixelType(String type) {
-    switch (type) {
-      case "int8":
-        return PixelType.INT8;
-      case "uint8":
-        return PixelType.UINT8;
-      case "int16":
-        return PixelType.INT16;
-      case "uint16":
-        return PixelType.UINT16;
-      case "int32":
-        return PixelType.INT32;
-      case "uint32":
-        return PixelType.UINT32;
-      case "float":
-        return PixelType.FLOAT32;
-      case "double":
-        return PixelType.FLOAT64;
-    }
-    throw new IllegalArgumentException("Unsupported pixel type: " + type);
-  }
+	private PixelType convertPixelType(String type) {
+		switch (type) {
+			case "int8":
+				return PixelType.INT8;
+			case "uint8":
+				return PixelType.UINT8;
+			case "int16":
+				return PixelType.INT16;
+			case "uint16":
+				return PixelType.UINT16;
+			case "int32":
+				return PixelType.INT32;
+			case "uint32":
+				return PixelType.UINT32;
+			case "float":
+				return PixelType.FLOAT32;
+			case "double":
+				return PixelType.FLOAT64;
+		}
+		throw new IllegalArgumentException("Unsupported pixel type: " + type);
+	}
 }

--- a/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBrowserCommand.java
+++ b/src/main/java/qupath/lib/images/servers/omero/OmeroWebImageServerBrowserCommand.java
@@ -186,58 +186,58 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 	private final String[] orphanedAttributes = new String[] {"Name"};
 	
 	private final String[] projectAttributes = new String[] {"Name", 
-			"Id",
-			"Description",
-			"Owner",
-			"Group",
-			"Num. datasets"};
+		"Id",
+		"Description",
+		"Owner",
+		"Group",
+		"Num. datasets"};
 	
 	private final String[] datasetAttributes = new String[] {"Name", 
-			"Id", 
-			"Description",
-			"Owner",
-			"Group",
-			"Num. images"};
+		"Id", 
+		"Description",
+		"Owner",
+		"Group",
+		"Num. images"};
 	
 	private final String[] imageAttributes = new String[] {"Name", 
-			"Id", 
-			"Owner",
-			"Group",
-			"Acquisition date",
-			"Image width",
-			"Image height",
-			"Num. channels",
-			"Num. z-slices",
-			"Num. timepoints",
-			"Pixel size X",
-			"Pixel size Y",
-			"Pixel size Z",
-			"Pixel type"};
-    
-    OmeroWebImageServerBrowserCommand(QuPathGUI qupath, OmeroWebClient client) {
-    	this.qupath = qupath;
-    	this.client = Objects.requireNonNull(client);
-    	this.serverURI = client.getServerURI();
-    }
-    
-    Stage getStage() {
-    	return dialog;
-    }
-    
-    @Override
-    public void run() {
-    	boolean loggedIn = true;
-    	if (!client.isLoggedIn())
-    		loggedIn = client.logIn();
-    	
-    	if (!loggedIn)
-    		return;
+		"Id", 
+		"Owner",
+		"Group",
+		"Acquisition date",
+		"Image width",
+		"Image height",
+		"Num. channels",
+		"Num. z-slices",
+		"Num. timepoints",
+		"Pixel size X",
+		"Pixel size Y",
+		"Pixel size Z",
+		"Pixel type"};
+	
+	OmeroWebImageServerBrowserCommand(QuPathGUI qupath, OmeroWebClient client) {
+		this.qupath = qupath;
+		this.client = Objects.requireNonNull(client);
+		this.serverURI = client.getServerURI();
+	}
+	
+	Stage getStage() {
+		return dialog;
+	}
+	
+	@Override
+	public void run() {
+		boolean loggedIn = true;
+		if (!client.isLoggedIn())
+			loggedIn = client.logIn();
+		
+		if (!loggedIn)
+			return;
 
-    	// Initialize class variables
-    	serverChildrenList = new ArrayList<>();
-    	orphanedImageList = FXCollections.observableArrayList();
-    	orphanedFolder = new OrphanedFolder(orphanedImageList);
-    	currentOrphanedCount = orphanedFolder.getCurrentCountProperty();
+		// Initialize class variables
+		serverChildrenList = new ArrayList<>();
+		orphanedImageList = FXCollections.observableArrayList();
+		orphanedFolder = new OrphanedFolder(orphanedImageList);
+		currentOrphanedCount = orphanedFolder.getCurrentCountProperty();
 		thumbnailBank = new ConcurrentHashMap<>();
 		projectMap = new ConcurrentHashMap<>();
 		datasetMap = new ConcurrentHashMap<>();
@@ -250,7 +250,7 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		comboGroup = new ComboBox<>();
 		comboOwner = new ComboBox<>();
 		filter = new TextField();
-    	
+		
 		BorderPane mainPane = new BorderPane();
 		BorderPane serverInfoPane = new BorderPane();
 		GridPane serverAttributePane = new GridPane();
@@ -310,18 +310,18 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		
 		// Create converter from Owner object to proper String
 		ownerStringConverter = new StringConverter<>() {
-		    @Override
-		    public String toString(Owner owner) {
-		    	if (owner != null)
-		    		return owner.getName();
-		    	return null;
-		    }
+			@Override
+			public String toString(Owner owner) {
+				if (owner != null)
+					return owner.getName();
+				return null;
+			}
 
-		    @Override
-		    public Owner fromString(String string) {
-		        return comboOwner.getItems().stream().filter(ap -> 
-		            ap.getName().equals(string)).findFirst().orElse(null);
-		    }
+			@Override
+			public Owner fromString(String string) {
+				return comboOwner.getItems().stream().filter(ap -> 
+					ap.getName().equals(string)).findFirst().orElse(null);
+			}
 		};
 		
 		// Populate orphaned image list
@@ -332,7 +332,7 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 				null).size()), 
 					// Binding triggered when the following change: loadingProperty/selected Group/selected Owner
 					orphanedFolder.getLoadingProperty(), comboGroup.getSelectionModel().selectedItemProperty(), comboOwner.getSelectionModel().selectedItemProperty())
-				);
+		);
 
 		// Bind the top label to the amount of orphaned images
 		loadingOrphanedLabel.textProperty().bind(Bindings.when(orphanedFolder.getLoadingProperty()).then(Bindings.concat("Loading image list (")
@@ -346,40 +346,40 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		tree.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 		tree.setCellFactory(n -> new OmeroObjectCell());
 		tree.setOnMouseClicked(e -> {
-	        if (e.getClickCount() == 2) {
-	        	var selectedItem = tree.getSelectionModel().getSelectedItem();
-	        	if (selectedItem != null && selectedItem.getValue().getType() == OmeroObjectType.IMAGE && isSupported(selectedItem.getValue())) {
-	        		if (qupath.getProject() == null) {
-                try {
-	        			  qupath.openImage(qupath.getViewer(), createObjectURI(selectedItem.getValue()), true, true);
-                } catch (IOException ioe) {
-                  Dialogs.showErrorMessage("Open image", "Error opening image\n" + ioe.getLocalizedMessage());
-                  logger.error(ioe.getMessage(), ioe);
-                  throw new RuntimeException(ioe);
-                }
-              }
-	        		else {
-	        			promptToImportOmeroImages(createObjectURI(selectedItem.getValue()));
-              }
-	        	}
-	        }
-	    });
+			if (e.getClickCount() == 2) {
+				var selectedItem = tree.getSelectionModel().getSelectedItem();
+				if (selectedItem != null && selectedItem.getValue().getType() == OmeroObjectType.IMAGE && isSupported(selectedItem.getValue())) {
+					if (qupath.getProject() == null) {
+						try {
+							qupath.openImage(qupath.getViewer(), createObjectURI(selectedItem.getValue()), true, true);
+						} catch (IOException ioe) {
+							Dialogs.showErrorMessage("Open image", "Error opening image\n" + ioe.getLocalizedMessage());
+							logger.error(ioe.getMessage(), ioe);
+							throw new RuntimeException(ioe);
+						}
+					}
+					else {
+						promptToImportOmeroImages(createObjectURI(selectedItem.getValue()));
+					}
+				}
+			}
+		});
 		
 		MenuItem moreInfoItem = new MenuItem("More info...");
 		MenuItem openBrowserItem = new MenuItem("Open in browser");
-	    MenuItem clipboardItem = new MenuItem("Copy to clipboard");
-	    MenuItem collapseItem = new MenuItem("Collapse all items");
+		MenuItem clipboardItem = new MenuItem("Copy to clipboard");
+		MenuItem collapseItem = new MenuItem("Collapse all items");
 
-	    // 'More info..' will open new AdvancedObjectInfo pane
-	    moreInfoItem.setOnAction(ev -> new AdvancedObjectInfo(tree.getSelectionModel().getSelectedItem().getValue()));
-	    moreInfoItem.disableProperty().bind(tree.getSelectionModel().selectedItemProperty().isNull()
+		// 'More info..' will open new AdvancedObjectInfo pane
+		moreInfoItem.setOnAction(ev -> new AdvancedObjectInfo(tree.getSelectionModel().getSelectedItem().getValue()));
+		moreInfoItem.disableProperty().bind(tree.getSelectionModel().selectedItemProperty().isNull()
 				.or(Bindings.size(tree.getSelectionModel().getSelectedItems()).isNotEqualTo(1)
 				.or(Bindings.createBooleanBinding(() -> tree.getSelectionModel().getSelectedItem() != null && tree.getSelectionModel().getSelectedItem().getValue().getType() == OmeroObjectType.ORPHANED_FOLDER, 
 						tree.getSelectionModel().selectedItemProperty()))));
-	    
-	    // Opens the OMERO object in a browser
-	    openBrowserItem.setOnAction(ev -> {
-	    	var selected = tree.getSelectionModel().getSelectedItems();
+		
+		// Opens the OMERO object in a browser
+		openBrowserItem.setOnAction(ev -> {
+			var selected = tree.getSelectionModel().getSelectedItems();
 			if (selected != null && !selected.isEmpty() && selected.size() == 1) {
 				if (selected.get(0).getValue() instanceof OmeroObjects.OrphanedFolder) {
 					Dialogs.showPlainMessage("Requesting orphaned folder", "Link to orphaned folder does not exist!");
@@ -387,12 +387,12 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 				}
 				QuPathGUI.openInBrowser(createObjectURI(selected.get(0).getValue()));
 			}
-	    });
-	    openBrowserItem.disableProperty().bind(tree.getSelectionModel().selectedItemProperty().isNull()
-	    		.or(Bindings.size(tree.getSelectionModel().getSelectedItems()).isNotEqualTo(1)));
-	    
-	    // Clipboard action will *not* fetch all the images in the selected object(s)
-	    clipboardItem.setOnAction(ev -> {
+		});
+		openBrowserItem.disableProperty().bind(tree.getSelectionModel().selectedItemProperty().isNull()
+				.or(Bindings.size(tree.getSelectionModel().getSelectedItems()).isNotEqualTo(1)));
+		
+		// Clipboard action will *not* fetch all the images in the selected object(s)
+		clipboardItem.setOnAction(ev -> {
 			var selected = tree.getSelectionModel().getSelectedItems();
 			if (selected != null && !selected.isEmpty()) {
 				ClipboardContent content = new ClipboardContent();
@@ -413,13 +413,13 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 				Dialogs.showInfoNotification("Copy URI to clipboard", "URI" + (uris.size() > 1 ? "s " : " ") + "successfully copied to clipboard");
 			} else
 				Dialogs.showWarningNotification("Copy URI to clipboard", "The item needs to be selected first!");
-	    });
-	    
-	    // Collapse all items in the tree
-	    collapseItem.setOnAction(ev -> collapseTreeView(tree.getRoot()));
-	    
-	    // Add the items to the context menu
-	    tree.setContextMenu(new ContextMenu(moreInfoItem, openBrowserItem, clipboardItem, collapseItem));
+		});
+		
+		// Collapse all items in the tree
+		collapseItem.setOnAction(ev -> collapseTreeView(tree.getRoot()));
+		
+		// Add the items to the context menu
+		tree.setContextMenu(new ContextMenu(moreInfoItem, openBrowserItem, clipboardItem, collapseItem));
 		
 		owners.add(Owner.getAllMembersOwner());
 		comboOwner.getItems().setAll(owners);
@@ -505,15 +505,15 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		});
 		valueCol.setCellFactory(n -> new TableCell<>() {
 			@Override
-	        protected void updateItem(String item, boolean empty) {
+			protected void updateItem(String item, boolean empty) {
 				super.updateItem(item, empty);
-	            if (empty || item == null) {
-	                setText(null);
-	                setGraphic(null);
-	            } else {
-	            	setText(item);
-	            	setTooltip(new Tooltip(item));	            	
-	            }
+				if (empty || item == null) {
+					setText(null);
+					setGraphic(null);
+				} else {
+					setText(item);
+					setTooltip(new Tooltip(item));					
+				}
 			}
 		});
 
@@ -591,7 +591,7 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 						Bindings.createBooleanBinding(() -> !tree.getSelectionModel().getSelectedItems().stream().allMatch(obj -> isSupported(obj.getValue())),
 								tree.getSelectionModel().selectedItemProperty())
 						)
-				);
+		);
 		
 		// Import button will fetch all the images in the selected object(s) and check their validity
 		importBtn.setOnMouseClicked(e -> {
@@ -621,17 +621,17 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 			}
 			if (qupath.getProject() == null) {
 				if (validUris.length == 1) {
-          try {
-					  qupath.openImage(qupath.getViewer(), validUris[0], true, true);
-          } catch (IOException ioe) {
-            Dialogs.showErrorMessage("Open image", "Error opening image\n" + ioe.getLocalizedMessage());
-            logger.error(ioe.getMessage(), ioe);
-            throw new RuntimeException(ioe);
-          }
-        }
+					try {
+						qupath.openImage(qupath.getViewer(), validUris[0], true, true);
+					} catch (IOException ioe) {
+						Dialogs.showErrorMessage("Open image", "Error opening image\n" + ioe.getLocalizedMessage());
+						logger.error(ioe.getMessage(), ioe);
+						throw new RuntimeException(ioe);
+					}
+				}
 				else {
 					Dialogs.showErrorMessage("Open OMERO images", "If you want to handle multiple images, you need to create a project first."); // Same as D&D for images
-        }
+				}
 				return;
 			}
 			promptToImportOmeroImages(validUris);
@@ -649,7 +649,7 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		
 		PaneTools.addGridRow(browseRightPane, 0, 0, null, canvas);
 		PaneTools.addGridRow(browseRightPane, 1, 0, null, description);
-        
+		
 		// Set alignment of canvas (with thumbnail)
 		GridPane.setHalignment(canvas, HPos.CENTER);
 
@@ -667,8 +667,8 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		comboOwner.setMaxWidth(Double.MAX_VALUE);
 		comboGroup.setMaxWidth(Double.MAX_VALUE);
 		filter.setMaxWidth(Double.MAX_VALUE);
-        browseLeftPane.setMaxWidth(Double.MAX_VALUE);
-        importBtn.setMaxWidth(Double.MAX_VALUE);
+		browseLeftPane.setMaxWidth(Double.MAX_VALUE);
+		importBtn.setMaxWidth(Double.MAX_VALUE);
 		description.setMaxHeight(Double.MAX_VALUE);
 		
 		// Set paddings & gaps
@@ -701,8 +701,8 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 			OmeroExtension.getOpenedBrowsers().remove(client);
 		});
 		dialog.showAndWait();
-    }
-    
+	}
+	
 	/**
 	 * Return a list of all children of the specified omeroObj, either by requesting them 
 	 * to the server or by retrieving the stored value from the maps. If a request was 
@@ -751,10 +751,10 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 	}
 
 	private Map<OmeroObjectType, BufferedImage> getOmeroIcons() {
-    	Map<OmeroObjectType, BufferedImage> map = new HashMap<>();
-    	var scheme = serverURI.getScheme();
-    	var host = serverURI.getHost();
-    	var port = serverURI.getPort();
+		Map<OmeroObjectType, BufferedImage> map = new HashMap<>();
+		var scheme = serverURI.getScheme();
+		var host = serverURI.getHost();
+		var port = serverURI.getPort();
 		try {
 			// Load project icon
 			map.put(OmeroObjectType.PROJECT, OmeroRequests.requestIcon(scheme, host, port, "folder16.png"));
@@ -773,20 +773,20 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		}
 		return map;
 	}
-    
-    /**
-     * Return a list of Strings representing the {@code OmeroObject}s in the parameter list.
-     * The returned Strings are the lower level of OMERO object possible (giving a Dataset 
-     * object should return Images URI as Strings). The list is filter according to the current 
-     * group/owner and filter text.
-     * 
-     * @param list of OmeroObjects
-     * @return list of constructed Strings
-     * @see OmeroTools#getURIs(URI)
-     */
-    private List<String> getObjectsURI(OmeroObject... list) {
-    	List<String> URIs = new ArrayList<>();
-    	for (OmeroObject obj: list) {
+	
+	/**
+	 * Return a list of Strings representing the {@code OmeroObject}s in the parameter list.
+	 * The returned Strings are the lower level of OMERO object possible (giving a Dataset 
+	 * object should return Images URI as Strings). The list is filter according to the current 
+	 * group/owner and filter text.
+	 * 
+	 * @param list of OmeroObjects
+	 * @return list of constructed Strings
+	 * @see OmeroTools#getURIs(URI)
+	 */
+	private List<String> getObjectsURI(OmeroObject... list) {
+		List<String> URIs = new ArrayList<>();
+		for (OmeroObject obj: list) {
 			if (obj.getType() == OmeroObjectType.ORPHANED_FOLDER) {
 				var filteredList = filterList(((OrphanedFolder)obj).getImageList(), comboGroup.getSelectionModel().getSelectedItem(), comboOwner.getSelectionModel().getSelectedItem(), null);
 				URIs.addAll(filteredList.stream().map(sub -> createObjectURI(sub)).collect(Collectors.toList()));
@@ -797,15 +797,15 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 					logger.error("Could not get URI for " + obj.getName() + ": {}", ex.getLocalizedMessage());
 				}
 			}
-    	}
-    	return URIs;
-    }
+		}
+		return URIs;
+	}
 
-    /**
-     * Reconstruct the URI of the given {@code OmeroObject} as a String.
-     * @param omeroObj
-     * @return
-     */
+	/**
+	 * Reconstruct the URI of the given {@code OmeroObject} as a String.
+	 * @param omeroObj
+	 * @return
+	 */
 	private String createObjectURI(OmeroObject omeroObj) {
 		return String.format("%s://%s%s/webclient/?show=%s-%d", 
 				serverURI.getScheme(), 
@@ -968,9 +968,9 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 	 * @return isSupported
 	 */
 	private boolean isSupported(OmeroObject omeroObj) {
-    if (client.hasMicroservice()) {
-      return true;
-    }
+		if (client.hasMicroservice()) {
+			return true;
+		}
 		if (omeroObj == null || omeroObj.getType() != OmeroObjectType.IMAGE)
 			return true;
 		return isUint8((Image)omeroObj) && has3Channels((Image)omeroObj);
@@ -993,14 +993,14 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 	 * @param item
 	 */
 	private static void expandTreeView(TreeItem<OmeroObject> item){
-	    if (item != null && !item.isLeaf()) {
-	    	if (!(item.getValue().getType() == OmeroObjectType.SERVER))
-	    		item.setExpanded(true);
-	    	
-    		for (var child: item.getChildren()) {
-    			expandTreeView(child);
-	        }
-	    }
+		if (item != null && !item.isLeaf()) {
+			if (!(item.getValue().getType() == OmeroObjectType.SERVER))
+				item.setExpanded(true);
+
+			for (var child: item.getChildren()) {
+				expandTreeView(child);
+			}
+		}
 	}
 	
 	/**
@@ -1008,11 +1008,11 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 	 * @param item
 	 */
 	private static void collapseTreeView(TreeItem<OmeroObject> item){
-	    if (item != null && !item.isLeaf() && item.getValue().getType() == OmeroObjectType.SERVER) {
-    		for (var child: item.getChildren()) {
-    			child.setExpanded(false);
-    		}
-	    }
+		if (item != null && !item.isLeaf() && item.getValue().getType() == OmeroObjectType.SERVER) {
+			for (var child: item.getChildren()) {
+				child.setExpanded(false);
+			}
+		}
 	}
 	
 		
@@ -1025,112 +1025,112 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		private Canvas tooltipCanvas = new Canvas();
 		
 		@Override
-        public void updateItem(OmeroObject item, boolean empty) {
-            super.updateItem(item, empty);
-            if (empty || item == null) {
-                setText(null);
-                setGraphic(null);
-                return;
-            }
+		public void updateItem(OmeroObject item, boolean empty) {
+			super.updateItem(item, empty);
+			if (empty || item == null) {
+				setText(null);
+				setGraphic(null);
+				return;
+			}
 
-            // Since cells are recycled, make sure they are not disabled or transparent
-        	setOpacity(1.0);
-        	disableProperty().unbind();
-        	setDisable(false);
-        	paintBufferedImageOnCanvas(null, tooltipCanvas, 0);
-        	
-        	String name;
-        	Tooltip tooltip = new Tooltip();
-        	BufferedImage icon = omeroIcons.get(item.getType());
-        	if (item.getType() == OmeroObjectType.SERVER)
-        		name = serverURI.getHost();
-        	else if (item.getType() == OmeroObjectType.PROJECT || item.getType() == OmeroObjectType.DATASET)
-        		name = item.getName() + " (" + item.getNChildren() + ")";
-        	else if (item.getType() == OmeroObjectType.ORPHANED_FOLDER) {
-        		// No need for 'text', as we're using the graphic component of the cell for orphaned folder
-        		setText("");
-        		var label = new Label("", iconCanvas);
-        		
-        		// Bind the label property to display the total amount of loaded orphaned images (for this Group/Owner)
-        		label.textProperty().bind(
-        				Bindings.when(orphanedFolder.getLoadingProperty())
-        					.then(Bindings.concat(item.getName(), " (loading...)"))
-        					.otherwise(Bindings.concat(item.getName(), " (", currentOrphanedCount, ")")));
+			// Since cells are recycled, make sure they are not disabled or transparent
+			setOpacity(1.0);
+			disableProperty().unbind();
+			setDisable(false);
+			paintBufferedImageOnCanvas(null, tooltipCanvas, 0);
+			
+			String name;
+			Tooltip tooltip = new Tooltip();
+			BufferedImage icon = omeroIcons.get(item.getType());
+			if (item.getType() == OmeroObjectType.SERVER)
+				name = serverURI.getHost();
+			else if (item.getType() == OmeroObjectType.PROJECT || item.getType() == OmeroObjectType.DATASET)
+				name = item.getName() + " (" + item.getNChildren() + ")";
+			else if (item.getType() == OmeroObjectType.ORPHANED_FOLDER) {
+				// No need for 'text', as we're using the graphic component of the cell for orphaned folder
+				setText("");
+				var label = new Label("", iconCanvas);
+				
+				// Bind the label property to display the total amount of loaded orphaned images (for this Group/Owner)
+				label.textProperty().bind(
+						Bindings.when(orphanedFolder.getLoadingProperty())
+							.then(Bindings.concat(item.getName(), " (loading...)"))
+							.otherwise(Bindings.concat(item.getName(), " (", currentOrphanedCount, ")")));
 
-        		// If orphaned images are still loading, disable the cell (prevent weird and unnecessary errors)
-        		disableProperty().bind(orphanedFolder.getLoadingProperty());
-        		if (icon != null)
-        			paintBufferedImageOnCanvas(icon, iconCanvas, 15);
-        		// Orphaned object is still 'selectable' via arrows (despite being disabled), which looks like a JavaFX bug..
-//            		orphanedFolder.getCurrentCountProperty().addListener((v, o, n) -> getDisclosureNode().setVisible(n.intValue() > 0 && !orphanedFolder.getLoadingProperty().get()));
-        		tooltip.setText(item.getName());
-        		setTooltip(tooltip);
-        		setGraphic(label);
-        		return;
-        	} else if (item.getType() == OmeroObjectType.IMAGE) {
-        		name = item.getName();
-        		GridPane gp = new GridPane();
-            	gp.addRow(0, tooltipCanvas, new Label(name));
-            	if (!isSupported(item)) {
-            		setOpacity(0.5);
-            		Label notSupportedLabel = new Label("Image not supported:");
-            		notSupportedLabel.setStyle("-fx-text-fill: red;");
-            		
-            		// Clarify to the user WHY it's not supported
-            		Label uint8 = new Label();
-            		if (isUint8((Image)item)) {
-            			uint8.setText("- uint8 " + Character.toString((char)10003));
-            		} else {
-            			uint8.setText("- uint8 " + Character.toString((char)10007));
-            			uint8.setStyle("-fx-text-fill: red;");
-            		}
-            		Label has3Channels = new Label();
-            		if (has3Channels((Image)item)) {
-            			has3Channels.setText("- 3 channels " + Character.toString((char)10003));
-            		} else {
-            			has3Channels.setText("- 3 channels " + Character.toString((char)10007));
-            			has3Channels.setStyle("-fx-text-fill: red;");
-            		}
-            		gp.addRow(1, notSupportedLabel, new HBox(uint8, has3Channels));
-            	}
-            	
-            	tooltip.setOnShowing(e -> {
-            		// Image tooltip shows the thumbnail (could show icon for other items, but icon is very low quality)
-            		if (thumbnailBank.containsKey(item.getId()))
-            			paintBufferedImageOnCanvas(thumbnailBank.get(item.getId()), tooltipCanvas, 100);
-            		else {
-            			// Get thumbnail from JSON API in separate thread
-            			executorThumbnails.submit(() -> {
-            				var loadedImg = OmeroTools.getThumbnail(serverURI, item.getId(), imgPrefSize);
-            				if (loadedImg != null) {
-            					thumbnailBank.put(item.getId(), loadedImg);
-            					Platform.runLater(() -> paintBufferedImageOnCanvas(loadedImg, tooltipCanvas, 100));
-            				}
-            			});							
-            		}
-            	});
-            	setText(name);
-            	setTooltip(tooltip);
-            	tooltip.setGraphic(gp);
-            } else {
-            	name = item.getName();
-            	if (!isSupported(item))
-            		setOpacity(0.5);
-            }
-        	
-        	// Paint icon
-        	if (icon != null) {
-    			paintBufferedImageOnCanvas(icon, iconCanvas, 15);
-    			setGraphic(iconCanvas);
-    		}
-        	
-        	if (item.getType() != OmeroObjectType.IMAGE) {
-        		tooltip.setText(name);
-        		tooltip.setGraphic(tooltipCanvas);        		
-        	}
-        	setTooltip(tooltip);
-        	setText(name);
-        }
+				// If orphaned images are still loading, disable the cell (prevent weird and unnecessary errors)
+				disableProperty().bind(orphanedFolder.getLoadingProperty());
+				if (icon != null)
+					paintBufferedImageOnCanvas(icon, iconCanvas, 15);
+				// Orphaned object is still 'selectable' via arrows (despite being disabled), which looks like a JavaFX bug..
+//					orphanedFolder.getCurrentCountProperty().addListener((v, o, n) -> getDisclosureNode().setVisible(n.intValue() > 0 && !orphanedFolder.getLoadingProperty().get()));
+				tooltip.setText(item.getName());
+				setTooltip(tooltip);
+				setGraphic(label);
+				return;
+			} else if (item.getType() == OmeroObjectType.IMAGE) {
+				name = item.getName();
+				GridPane gp = new GridPane();
+				gp.addRow(0, tooltipCanvas, new Label(name));
+				if (!isSupported(item)) {
+					setOpacity(0.5);
+					Label notSupportedLabel = new Label("Image not supported:");
+					notSupportedLabel.setStyle("-fx-text-fill: red;");
+					
+					// Clarify to the user WHY it's not supported
+					Label uint8 = new Label();
+					if (isUint8((Image)item)) {
+						uint8.setText("- uint8 " + Character.toString((char)10003));
+					} else {
+						uint8.setText("- uint8 " + Character.toString((char)10007));
+						uint8.setStyle("-fx-text-fill: red;");
+					}
+					Label has3Channels = new Label();
+					if (has3Channels((Image)item)) {
+						has3Channels.setText("- 3 channels " + Character.toString((char)10003));
+					} else {
+						has3Channels.setText("- 3 channels " + Character.toString((char)10007));
+						has3Channels.setStyle("-fx-text-fill: red;");
+					}
+					gp.addRow(1, notSupportedLabel, new HBox(uint8, has3Channels));
+				}
+				
+				tooltip.setOnShowing(e -> {
+					// Image tooltip shows the thumbnail (could show icon for other items, but icon is very low quality)
+					if (thumbnailBank.containsKey(item.getId()))
+						paintBufferedImageOnCanvas(thumbnailBank.get(item.getId()), tooltipCanvas, 100);
+					else {
+						// Get thumbnail from JSON API in separate thread
+						executorThumbnails.submit(() -> {
+							var loadedImg = OmeroTools.getThumbnail(serverURI, item.getId(), imgPrefSize);
+							if (loadedImg != null) {
+								thumbnailBank.put(item.getId(), loadedImg);
+								Platform.runLater(() -> paintBufferedImageOnCanvas(loadedImg, tooltipCanvas, 100));
+							}
+						});							
+					}
+				});
+				setText(name);
+				setTooltip(tooltip);
+				tooltip.setGraphic(gp);
+			} else {
+				name = item.getName();
+				if (!isSupported(item))
+					setOpacity(0.5);
+			}
+			
+			// Paint icon
+			if (icon != null) {
+				paintBufferedImageOnCanvas(icon, iconCanvas, 15);
+				setGraphic(iconCanvas);
+			}
+			
+			if (item.getType() != OmeroObjectType.IMAGE) {
+				tooltip.setText(name);
+				tooltip.setGraphic(tooltipCanvas);        		
+			}
+			setTooltip(tooltip);
+			setText(name);
+		}
 	}
 	
 	/**
@@ -1264,8 +1264,8 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		 * @return
 		 */
 		private <T> Predicate<T> distinctByName(Function<? super T, ?> keyExtractor) {
-		    Set<Object> seen = ConcurrentHashMap.newKeySet();
-		    return t -> seen.add(keyExtractor.apply(t));
+			Set<Object> seen = ConcurrentHashMap.newKeySet();
+			return t -> seen.add(keyExtractor.apply(t));
 		}
 	}
 	
@@ -1369,74 +1369,74 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 			var anns = omeroAnnotations.getAnnotations();
 			String tooltip;
 			switch (omeroAnnotations.getType()) {
-			case TAG:
-				for (var ann: anns) {
-					var ann2 = (TagAnnotation)ann;
-					var addedBy = omeroAnnotations.getExperimenters().parallelStream()
-							.filter(e -> e .getId() == ann2.addedBy().getId())
-							.map(e -> e.getFullName())
-							.findAny().get();
-					var creator = omeroAnnotations.getExperimenters().parallelStream()
-							.filter(e -> e .getId() == ann2.getOwner().getId())
-							.map(e -> e.getFullName())
-							.findAny().get();
-					tooltip = String.format("Added by: %s%sCreated by: %s", addedBy, System.lineSeparator(), creator);
-					PaneTools.addGridRow(gp, gp.getRowCount(), 0, tooltip, new Label(ann2.getValue()));
-				}
-				break;
-			case MAP:
-				for (var ann: anns) {
-					var ann2 = (MapAnnotation)ann;
-					var addedBy = omeroAnnotations.getExperimenters().parallelStream()
-							.filter(e -> e .getId() == ann2.addedBy().getId())
-							.map(e -> e.getFullName())
-							.findAny().get();
-					var creator = omeroAnnotations.getExperimenters().parallelStream()
-							.filter(e -> e .getId() == ann2.getOwner().getId())
-							.map(e -> e.getFullName())
-							.findAny().get();
-					for (var value: ann2.getValues().entrySet())
-						addKeyValueToGrid(gp, true, "Added by: " + addedBy + System.lineSeparator() + "Created by: " + creator, value.getKey(), value.getValue().isEmpty() ? "-" : value.getValue());
-				}
-				break;
-			case ATTACHMENT:
-				for (var ann: anns) {
-					var ann2 = (FileAnnotation)ann;
-					var addedBy = omeroAnnotations.getExperimenters().parallelStream()
-							.filter(e -> e .getId() == ann2.addedBy().getId())
-							.map(e -> e.getFullName())
-							.findAny().get();
-					var creator = omeroAnnotations.getExperimenters().parallelStream()
-							.filter(e -> e .getId() == ann2.getOwner().getId())
-							.map(e -> e.getFullName())
-							.findAny().get();
-					tooltip = String.format("Added by: %s%sCreated by: %s%sType: %s", addedBy, System.lineSeparator(), creator, System.lineSeparator(), ann2.getMimeType());
-					PaneTools.addGridRow(gp, gp.getRowCount(), 0, tooltip, new Label(ann2.getFilename() + " (" + ann2.getFileSize() + " bytes)"));
-				}
-				break;
-			case COMMENT:
-				for (var ann: anns) {
-					var ann2 = (CommentAnnotation)ann;
-					var addedBy = omeroAnnotations.getExperimenters().parallelStream()
-							.filter(e -> e .getId() == ann2.addedBy().getId())
-							.map(e -> e.getFullName())
-							.findAny().get();
-					PaneTools.addGridRow(gp, gp.getRowCount(), 0, "Added by " + addedBy, new Label(ann2.getValue()));
-				}
-				break;
-			case RATING:
-        int rating = 0;
-				for (var ann: anns) {
-					var ann2 = (LongAnnotation)ann;
-					rating += ann2.getValue();
-				}
-				
-				for (int i = 0; i < Math.round(rating/anns.size()); i++)
-					gp.add(GlyphFontRegistry.font("icomoon").create("\u2605").size(QuPathGUI.TOOLBAR_ICON_SIZE).color(javafx.scene.paint.Color.GRAY), i, 0);
-				gp.setHgap(10.0);
-				break;
-			default:
-				logger.error("OMERO annotation not supported: {}", omeroAnnotations.getType());
+				case TAG:
+					for (var ann: anns) {
+						var ann2 = (TagAnnotation)ann;
+						var addedBy = omeroAnnotations.getExperimenters().parallelStream()
+								.filter(e -> e .getId() == ann2.addedBy().getId())
+								.map(e -> e.getFullName())
+								.findAny().get();
+						var creator = omeroAnnotations.getExperimenters().parallelStream()
+								.filter(e -> e .getId() == ann2.getOwner().getId())
+								.map(e -> e.getFullName())
+								.findAny().get();
+						tooltip = String.format("Added by: %s%sCreated by: %s", addedBy, System.lineSeparator(), creator);
+						PaneTools.addGridRow(gp, gp.getRowCount(), 0, tooltip, new Label(ann2.getValue()));
+					}
+					break;
+				case MAP:
+					for (var ann: anns) {
+						var ann2 = (MapAnnotation)ann;
+						var addedBy = omeroAnnotations.getExperimenters().parallelStream()
+								.filter(e -> e .getId() == ann2.addedBy().getId())
+								.map(e -> e.getFullName())
+								.findAny().get();
+						var creator = omeroAnnotations.getExperimenters().parallelStream()
+								.filter(e -> e .getId() == ann2.getOwner().getId())
+								.map(e -> e.getFullName())
+								.findAny().get();
+						for (var value: ann2.getValues().entrySet())
+							addKeyValueToGrid(gp, true, "Added by: " + addedBy + System.lineSeparator() + "Created by: " + creator, value.getKey(), value.getValue().isEmpty() ? "-" : value.getValue());
+					}
+					break;
+				case ATTACHMENT:
+					for (var ann: anns) {
+						var ann2 = (FileAnnotation)ann;
+						var addedBy = omeroAnnotations.getExperimenters().parallelStream()
+								.filter(e -> e .getId() == ann2.addedBy().getId())
+								.map(e -> e.getFullName())
+								.findAny().get();
+						var creator = omeroAnnotations.getExperimenters().parallelStream()
+								.filter(e -> e .getId() == ann2.getOwner().getId())
+								.map(e -> e.getFullName())
+								.findAny().get();
+						tooltip = String.format("Added by: %s%sCreated by: %s%sType: %s", addedBy, System.lineSeparator(), creator, System.lineSeparator(), ann2.getMimeType());
+						PaneTools.addGridRow(gp, gp.getRowCount(), 0, tooltip, new Label(ann2.getFilename() + " (" + ann2.getFileSize() + " bytes)"));
+					}
+					break;
+				case COMMENT:
+					for (var ann: anns) {
+						var ann2 = (CommentAnnotation)ann;
+						var addedBy = omeroAnnotations.getExperimenters().parallelStream()
+								.filter(e -> e .getId() == ann2.addedBy().getId())
+								.map(e -> e.getFullName())
+								.findAny().get();
+						PaneTools.addGridRow(gp, gp.getRowCount(), 0, "Added by " + addedBy, new Label(ann2.getValue()));
+					}
+					break;
+				case RATING:
+					int rating = 0;
+					for (var ann: anns) {
+						var ann2 = (LongAnnotation)ann;
+						rating += ann2.getValue();
+					}
+					
+					for (int i = 0; i < Math.round(rating/anns.size()); i++)
+						gp.add(GlyphFontRegistry.font("icomoon").create("\u2605").size(QuPathGUI.TOOLBAR_ICON_SIZE).color(javafx.scene.paint.Color.GRAY), i, 0);
+					gp.setHgap(10.0);
+					break;
+				default:
+					logger.error("OMERO annotation not supported: {}", omeroAnnotations.getType());
 			}
 			
 			sp.setContent(gp);
@@ -1526,12 +1526,12 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		private ExecutorService executorThumbnail;
 		
 		private final Pattern patternRow = Pattern.compile("<tr id=\"(.+?)-(.+?)\".+?</tr>", Pattern.DOTALL | Pattern.MULTILINE);
-	    private final Pattern patternDesc = Pattern.compile("<td class=\"desc\"><a>(.+?)</a></td>");
-	    private final Pattern patternDate = Pattern.compile("<td class=\"date\">(.+?)</td>");
-	    private final Pattern patternGroup = Pattern.compile("<td class=\"group\">(.+?)</td>");
-	    private final Pattern patternLink = Pattern.compile("<td><a href=\"(.+?)\"");
+		private final Pattern patternDesc = Pattern.compile("<td class=\"desc\"><a>(.+?)</a></td>");
+		private final Pattern patternDate = Pattern.compile("<td class=\"date\">(.+?)</td>");
+		private final Pattern patternGroup = Pattern.compile("<td class=\"group\">(.+?)</td>");
+		private final Pattern patternLink = Pattern.compile("<td><a href=\"(.+?)\"");
 
-	    private final Pattern[] patterns = new Pattern[] {patternDesc, patternDate, patternDate, patternGroup, patternLink};
+		private final Pattern[] patterns = new Pattern[] {patternDesc, patternDate, patternDate, patternGroup, patternLink};
 		
 		private AdvancedSearch() {
 			
@@ -1644,7 +1644,7 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 							}
 							return null;
 						}).map(item -> item.toString())
-						  .toArray(String[]::new);
+						.toArray(String[]::new);
 				if (URIs.length > 0)
 					promptToImportOmeroImages(URIs);
 				else
@@ -1667,33 +1667,33 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 			PaneTools.addGridRow(searchOptionPane, row++, 0, "Import selected image", importBtn);
 			
 			TableColumn<SearchResult, SearchResult> typeCol = new TableColumn<>("Type");
-		    TableColumn<SearchResult, String> nameCol = new TableColumn<>("Name");
-		    TableColumn<SearchResult, String> acquisitionCol = new TableColumn<>("Acquired");
-		    TableColumn<SearchResult, String> importedCol = new TableColumn<>("Imported");
-		    TableColumn<SearchResult, String> groupCol = new TableColumn<>("Group");
-		    TableColumn<SearchResult, SearchResult> linkCol = new TableColumn<>("Link");
-		    
-		    typeCol.setCellValueFactory(n -> new ReadOnlyObjectWrapper<>(n.getValue()));
-		    typeCol.setCellFactory(n -> new TableCell<>() {
-		    	
+			TableColumn<SearchResult, String> nameCol = new TableColumn<>("Name");
+			TableColumn<SearchResult, String> acquisitionCol = new TableColumn<>("Acquired");
+			TableColumn<SearchResult, String> importedCol = new TableColumn<>("Imported");
+			TableColumn<SearchResult, String> groupCol = new TableColumn<>("Group");
+			TableColumn<SearchResult, SearchResult> linkCol = new TableColumn<>("Link");
+			
+			typeCol.setCellValueFactory(n -> new ReadOnlyObjectWrapper<>(n.getValue()));
+			typeCol.setCellFactory(n -> new TableCell<>() {
+				
 				@Override
-		        protected void updateItem(SearchResult item, boolean empty) {
-		            super.updateItem(item, empty);
-		            BufferedImage img = null;
-		            Canvas canvas = new Canvas(prefScale, prefScale);
-		            
-		            if (item == null || empty) {
+				protected void updateItem(SearchResult item, boolean empty) {
+					super.updateItem(item, empty);
+					BufferedImage img = null;
+					Canvas canvas = new Canvas(prefScale, prefScale);
+					
+					if (item == null || empty) {
 						setTooltip(null);
 						setText(null);
 						return;
 					}
-		            
-		            if (item.type.toLowerCase().equals("project"))
-		            	img = omeroIcons.get(OmeroObjectType.PROJECT);
-		            else if (item.type.toLowerCase().equals("dataset"))
-		            	img = omeroIcons.get(OmeroObjectType.DATASET);
-		            else {
-		            	// To avoid ConcurrentModificationExceptions
+					
+					if (item.type.toLowerCase().equals("project"))
+						img = omeroIcons.get(OmeroObjectType.PROJECT);
+					else if (item.type.toLowerCase().equals("dataset"))
+						img = omeroIcons.get(OmeroObjectType.DATASET);
+					else {
+						// To avoid ConcurrentModificationExceptions
 						var it = thumbnailBank.keySet().iterator();
 						synchronized (thumbnailBank) {
 							while (it.hasNext()) {
@@ -1706,60 +1706,60 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 						}
 					}
 
-		            if (img != null) {
-		            	var wi = paintBufferedImageOnCanvas(img, canvas, prefScale);
-		            	Tooltip tooltip = new Tooltip();
-		            	if (item.type.toLowerCase().equals("image")) {
-		            		// Setting tooltips on hover
-		            		ImageView imageView = new ImageView(wi);
-		            		imageView.setFitHeight(250);
-		            		imageView.setPreserveRatio(true);
-		            		tooltip.setGraphic(imageView);
-		            	} else
-		            		tooltip.setText(item.name);
-		            			            	
-		            	setText(null);
-		            	setTooltip(tooltip);
-		            }
+					if (img != null) {
+						var wi = paintBufferedImageOnCanvas(img, canvas, prefScale);
+						Tooltip tooltip = new Tooltip();
+						if (item.type.toLowerCase().equals("image")) {
+							// Setting tooltips on hover
+							ImageView imageView = new ImageView(wi);
+							imageView.setFitHeight(250);
+							imageView.setPreserveRatio(true);
+							tooltip.setGraphic(imageView);
+						} else
+							tooltip.setText(item.name);
 
-		            setGraphic(canvas);
+						setText(null);
+						setTooltip(tooltip);
+					}
+
+					setGraphic(canvas);
 					setAlignment(Pos.CENTER);
 				}
-		    });
-		    nameCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().name));
-		    acquisitionCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().acquired.toString()));
-		    importedCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().imported.toString()));
-		    groupCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().group));
-		    linkCol.setCellValueFactory(n -> new ReadOnlyObjectWrapper<>(n.getValue()));
-		    linkCol.setCellFactory(n -> new TableCell<>() {
-		        private final Button button = new Button("Link");
+			});
+			nameCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().name));
+			acquisitionCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().acquired.toString()));
+			importedCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().imported.toString()));
+			groupCol.setCellValueFactory(n -> new ReadOnlyStringWrapper(n.getValue().group));
+			linkCol.setCellValueFactory(n -> new ReadOnlyObjectWrapper<>(n.getValue()));
+			linkCol.setCellFactory(n -> new TableCell<>() {
+				private final Button button = new Button("Link");
 
-		        @Override
-		        protected void updateItem(SearchResult item, boolean empty) {
-		            super.updateItem(item, empty);
-		            if (item == null) {
-		                setGraphic(null);
-		                return;
-		            }
+				@Override
+				protected void updateItem(SearchResult item, boolean empty) {
+					super.updateItem(item, empty);
+					if (item == null) {
+						setGraphic(null);
+						return;
+					}
 
-		            button.setOnAction(e -> QuPathGUI.openInBrowser(item.link.toString()));
-		            setGraphic(button);
-		        }
-		    });
-		    
-		    resultsTableView.getColumns().add(typeCol);
-		    resultsTableView.getColumns().add(nameCol);
-		    resultsTableView.getColumns().add(acquisitionCol);
-		    resultsTableView.getColumns().add(importedCol);
-		    resultsTableView.getColumns().add(groupCol);
-		    resultsTableView.getColumns().add(linkCol);
+					button.setOnAction(e -> QuPathGUI.openInBrowser(item.link.toString()));
+					setGraphic(button);
+				}
+			});
+			
+			resultsTableView.getColumns().add(typeCol);
+			resultsTableView.getColumns().add(nameCol);
+			resultsTableView.getColumns().add(acquisitionCol);
+			resultsTableView.getColumns().add(importedCol);
+			resultsTableView.getColumns().add(groupCol);
+			resultsTableView.getColumns().add(linkCol);
 			resultsTableView.setItems(obsResults);
 			resultsTableView.getColumns().forEach(e -> e.setStyle( "-fx-alignment: CENTER;"));
 			
 			resultsTableView.setOnMouseClicked(e -> {
-		        if (e.getClickCount() == 2) {
-		        	var selectedItem = resultsTableView.getSelectionModel().getSelectedItem();
-		        	if (selectedItem != null) {
+				if (e.getClickCount() == 2) {
+					var selectedItem = resultsTableView.getSelectionModel().getSelectedItem();
+					if (selectedItem != null) {
 						try {
 							List<URI> URIs = OmeroTools.getURIs(selectedItem.link.toURI());
 							var uriStrings = URIs.parallelStream().map(uriTemp -> uriTemp.toString()).toArray(String[]::new);
@@ -1770,9 +1770,9 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 						} catch (IOException | URISyntaxException ex) {
 							logger.error("Error while importing " + selectedItem.name + ": {}", ex.getLocalizedMessage());
 						}
-		        	}
-		        }
-		    });
+					}
+				}
+			});
 			
 			resultsTableView.getSelectionModel().selectedItemProperty().addListener((v, o, n) -> {
 				if (n == null)
@@ -1850,33 +1850,33 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 		
 		private List<SearchResult> parseHTML(String response) {
 			List<SearchResult> searchResults = new ArrayList<>();
-	        Matcher rowMatcher = patternRow.matcher(response);
-	        while (rowMatcher.find()) {
-	            String[] values = new String[7];
-	            String row = rowMatcher.group(0);
-	            values[0] = rowMatcher.group(1);
-	            values[1] = rowMatcher.group(2);
-	            String value = "";
-	            
-	            int nValue = 2;
-	            for (var pattern: patterns) {
-	                Matcher matcher = pattern.matcher(row);
-	                if (matcher.find()) {
-	                    value = matcher.group(1);
-	                    row = row.substring(matcher.end());
-	                }
-	                values[nValue++] = value;
-	            }
-	            
-	            try {
+			Matcher rowMatcher = patternRow.matcher(response);
+			while (rowMatcher.find()) {
+				String[] values = new String[7];
+				String row = rowMatcher.group(0);
+				values[0] = rowMatcher.group(1);
+				values[1] = rowMatcher.group(2);
+				String value = "";
+				
+				int nValue = 2;
+				for (var pattern: patterns) {
+					Matcher matcher = pattern.matcher(row);
+					if (matcher.find()) {
+						value = matcher.group(1);
+						row = row.substring(matcher.end());
+					}
+					values[nValue++] = value;
+				}
+				
+				try {
 					SearchResult obj = new SearchResult(values);
 					searchResults.add(obj);
 				} catch (Exception e) {
 					logger.error("Could not parse search result. {}", e.getLocalizedMessage());
 				}
-	        }
-	        
-	        return searchResults;
+			}
+			
+			return searchResults;
 		}
 		
 		private void updateTableView(List<SearchResult> results) {
@@ -1910,7 +1910,7 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 			if (executorThumbnail != null)
 				executorThumbnail.shutdownNow();
 			executorThumbnail = Executors.newSingleThreadExecutor(ThreadTools.createThreadFactory("batch-thumbnail-request", true));
-			 
+
 			for (var searchResult: thumbnailsToQuery) {
 				executorThumbnail.submit(() -> {
 					BufferedImage thumbnail = OmeroTools.getThumbnail(serverURI, searchResult.id, imgPrefSize);
@@ -1949,8 +1949,8 @@ public class OmeroWebImageServerBrowserCommand implements Runnable {
 	 * Request closure of the dialog
 	 */
 	void requestClose() {
-    	if (dialog != null)
-    		dialog.fireEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSE_REQUEST));
+		if (dialog != null)
+			dialog.fireEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSE_REQUEST));
 	}
 	
 	/**


### PR DESCRIPTION
Split from discussion in #17. This adds a minimal checkstyle configuration to enforce tab indentation instead of spaces, and fixes all resulting warnings. While many files are touched, it should be whitespace only with no change in actual behavior.